### PR TITLE
Add text normalization and phonetic utilities

### DIFF
--- a/openodia/__init__.py
+++ b/openodia/__init__.py
@@ -7,6 +7,7 @@ from ._letters import Letters as alphabet
 from ._odianames import Names as name
 from ._summarization import WordFrequency
 from ._translate import odia_to_other_lang, other_lang_to_odia, universal_translation
+from .textutils import normalize_text, phonetic_odia
 from ._understandData import UnderstandData as ud
 
 __all__ = [
@@ -17,4 +18,6 @@ __all__ = [
     "odia_to_other_lang",
     "universal_translation",
     "WordFrequency",
+    "normalize_text",
+    "phonetic_odia",
 ]

--- a/openodia/textutils.py
+++ b/openodia/textutils.py
@@ -1,0 +1,124 @@
+"""Utility functions for text normalization and phonetic conversion."""
+
+from __future__ import annotations
+
+import string
+import unicodedata
+
+__all__ = ["normalize_text", "phonetic_odia"]
+
+
+def normalize_text(text: str | None) -> str:
+    """Normalize text by removing punctuation and collapsing whitespace."""
+    if text is None:
+        return ""
+
+    normalized = unicodedata.normalize("NFC", str(text)).lower()
+    punctuation_set = set(string.punctuation + "।")
+    normalized = "".join(ch for ch in normalized if ch not in punctuation_set)
+    normalized = " ".join(normalized.split())
+    return normalized
+
+
+_ODIA_PHONETIC_MAP = {
+    "ଅ": "a",
+    "ଆ": "aa",
+    "ଇ": "i",
+    "ଈ": "ii",
+    "ଉ": "u",
+    "ଊ": "uu",
+    "ଋ": "r",
+    "ଌ": "l",
+    "ଏ": "e",
+    "ଐ": "ai",
+    "ଓ": "o",
+    "ଔ": "au",
+    "କ": "ka",
+    "ଖ": "kha",
+    "ଗ": "ga",
+    "ଘ": "gha",
+    "ଙ": "nga",
+    "ଚ": "ca",
+    "ଛ": "cha",
+    "ଜ": "ja",
+    "ଝ": "jha",
+    "ଞ": "nya",
+    "ଟ": "ta",
+    "ଠ": "tha",
+    "ଡ": "da",
+    "ଢ": "dha",
+    "ଣ": "na",
+    "ତ": "ta",
+    "ଥ": "tha",
+    "ଦ": "da",
+    "ଧ": "dha",
+    "ନ": "na",
+    "ପ": "pa",
+    "ଫ": "pha",
+    "ବ": "ba",
+    "ଭ": "bha",
+    "ମ": "ma",
+    "ୟ": "ya",
+    "ର": "ra",
+    "ଲ": "la",
+    "ଳ": "la",
+    "ଵ": "va",
+    "ଶ": "sha",
+    "ଷ": "ssa",
+    "ସ": "sa",
+    "ହ": "ha",
+    "୦": "0",
+    "୧": "1",
+    "୨": "2",
+    "୩": "3",
+    "୪": "4",
+    "୫": "5",
+    "୬": "6",
+    "୭": "7",
+    "୮": "8",
+    "୯": "9",
+}
+
+_MATRA_MAP = {
+    "ା": "aa",
+    "ି": "i",
+    "ୀ": "ii",
+    "ୁ": "u",
+    "ୂ": "uu",
+    "ୃ": "ru",
+    "ୄ": "ruu",
+    "େ": "e",
+    "ୈ": "ai",
+    "ୋ": "o",
+    "ୌ": "au",
+}
+
+_HALANT = "\u0b4d"
+
+
+def phonetic_odia(text: str | None) -> str:
+    """Return a very simple phonetic Latin representation of Odia text."""
+    if text is None:
+        return ""
+
+    result: list[str] = []
+    for char in text:
+        if char == _HALANT:
+            if result and result[-1].endswith("a"):
+                result[-1] = result[-1][:-1]
+            continue
+
+        if char in _MATRA_MAP:
+            if result:
+                if result[-1].endswith("a"):
+                    result[-1] = result[-1][:-1] + _MATRA_MAP[char]
+                else:
+                    result[-1] += _MATRA_MAP[char]
+            else:
+                result.append(_MATRA_MAP[char])
+            continue
+
+        result.append(_ODIA_PHONETIC_MAP.get(char, char))
+
+    return "".join(result)
+

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,6 +12,8 @@ from openodia import (
     odia_to_other_lang,
     universal_translation,
     WordFrequency,
+    normalize_text,
+    phonetic_odia,
 )
 
 
@@ -34,12 +36,14 @@ class TestInit:
         """Test that all __all__ exports are available"""
         expected_exports = [
             "alphabet",
-            "name", 
+            "name",
             "ud",
             "other_lang_to_odia",
             "odia_to_other_lang",
             "universal_translation",
             "WordFrequency",
+            "normalize_text",
+            "phonetic_odia",
         ]
         
         for export in expected_exports:

--- a/tests/test_textutils.py
+++ b/tests/test_textutils.py
@@ -1,0 +1,26 @@
+import pytest
+
+from openodia import normalize_text, phonetic_odia
+
+
+class TestTextUtils:
+    def test_normalize_simple(self):
+        assert normalize_text("Hello, World!") == "hello world"
+
+    def test_normalize_odia_punctuation(self):
+        assert normalize_text("ନମସ୍କାର!") == "ନମସ୍କାର"
+
+    def test_normalize_none(self):
+        assert normalize_text(None) == ""
+
+    def test_phonetic_basic(self):
+        assert phonetic_odia("ନମସ୍କାର") == "namaskaara"
+
+    def test_phonetic_with_halant(self):
+        assert phonetic_odia("ଜଗନ୍ନାଥ") == "jagannaatha"
+
+    def test_phonetic_empty(self):
+        assert phonetic_odia("") == ""
+
+    def test_phonetic_none(self):
+        assert phonetic_odia(None) == ""


### PR DESCRIPTION
## Summary
- create `textutils` module with normalization and phonetic conversion helpers
- expose helpers in `openodia.__init__`
- test new utilities and update existing init tests

## Testing
- `pip install faker rich deep-translator numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffe24ab74832e9be8c2cb8b94dc6e