### PR TITLE
Add basic Odia stemming functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,29 @@ python setup.py install
 
 ## Usage and Documentation
 
-For usage and further documentation please visit the [Documentation](https://openodia.soumendrak.com/) page. 
+For usage and further documentation please visit the [Documentation](https://openodia.soumendrak.com/) page.
+
+### Stemming
+
+Basic stemming support is available via a simple rule-based stemmer.
+
+```python
+from openodia import stem_word, stem_text
+
+stem_word("ପିଲାମାନେ")
+```
+will return:
+
+```python
+'ପିଲା'
+```
+
+`stem_text` can be used for whole sentences:
+
+```python
+stem_text("ପିଲାମାନେ ବইଗୁଡ଼ିକ ପଢ଼ୁଛନ୍ତି")
+```
+which gives `"ପିଲା ବଇ ପଢ଼ୁଛ"`.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ The tools are available in Odia language.
 - [x] [Detect Odia Language](#detect-odia-language)
 - [x] [Word Tokenizer](#word-tokenizer)
 - [x] [Remove stopwords](#remove-stopwords)
+- [x] [Stemming](#stemming)
 - [x] [Google Translate](#translation)
 - [x] [Automatic extractive text summarization](#automatic-extractive-text-summarization)
 - [x] [Add Dictionary corpus](#offline-dictionary)
@@ -236,6 +237,25 @@ ud.remove_stopwords("ରାମ ଓ ସୀତା ଆମକୁ ଆଶୀର୍ବ�
 '''
 ```
 Here the stopwords `ଓ` and `ଦେଇଛନ୍ତି` are removed from the text.
+
+### :material-cut: Stemming
+
+A lightweight stemmer removes common suffixes from words.
+
+```python
+from openodia import stem_word
+
+stem_word("ପିଲାମାନେ")
+```
+returns `"ପିଲା"`.
+
+Use :func:`stem_text` for a full sentence:
+
+```python
+from openodia import stem_text
+stem_text("ପିଲାମାନେ ବইଗୁଡ଼ିକ ପଢ଼ୁଛନ୍ତି")
+```
+which outputs `"ପିଲା ବଇ ପଢ଼ୁଛ"`.
 
 ### :material-translate: Translation
 

--- a/openodia/__init__.py
+++ b/openodia/__init__.py
@@ -8,6 +8,7 @@ from ._odianames import Names as name
 from ._summarization import WordFrequency
 from ._translate import odia_to_other_lang, other_lang_to_odia, universal_translation
 from ._understandData import UnderstandData as ud
+from .stemming import stem_word, stem_text
 
 __all__ = [
     "alphabet",
@@ -17,4 +18,6 @@ __all__ = [
     "odia_to_other_lang",
     "universal_translation",
     "WordFrequency",
+    "stem_word",
+    "stem_text",
 ]

--- a/openodia/stemming.py
+++ b/openodia/stemming.py
@@ -1,0 +1,54 @@
+"""Simple rule-based stemmer for Odia language."""
+
+from typing import Iterable, List
+
+from ._understandData import UnderstandData as ud
+
+# Common Odia suffixes that can be stripped to obtain a crude stem
+_SUFFIXES = [
+    "ମାନେ",
+    "ମାନଙ୍କର",
+    "ମାନଙ୍କ",
+    "ମାନ",
+    "ଗୁଡ଼ିକ",
+    "ଗୁଡିକ",
+    "ଗୁଡ଼ିକର",
+    "ଗୁଡିକର",
+    "ଇବା",
+    "ଇଲା",
+    "ଇଲେ",
+    "ଲା",
+    "ଲେ",
+    "ନ୍ତି",
+    "ନ୍ତୁ",
+    "ଟି",
+    "ଟୀ",
+    "କୁ",
+    "ରୁ",
+    "ରେ",
+    "ର",
+]
+
+
+def stem_word(word: str) -> str:
+    """Return a crude stem for a single word.
+
+    The algorithm naively strips a set of known suffixes. If none of the
+    suffixes match the input word, it is returned unchanged.
+    """
+    for suf in sorted(_SUFFIXES, key=len, reverse=True):
+        if word.endswith(suf) and len(word) > len(suf):
+            return word[: -len(suf)]
+    return word
+
+
+def stem_words(words: Iterable[str]) -> List[str]:
+    """Stem each token from an iterable of words."""
+    return [stem_word(w) for w in words]
+
+
+def stem_text(text: str) -> str:
+    """Stem all words in a string and return a whitespace joined string."""
+    tokens = ud.word_tokenizer(text)
+    stemmed = stem_words(tokens)
+    return " ".join(stemmed)

--- a/tests/test_stemming.py
+++ b/tests/test_stemming.py
@@ -1,0 +1,13 @@
+from openodia import stem_word, stem_text
+
+
+def test_stem_word_examples():
+    assert stem_word("ପିଲାମାନେ") == "ପିଲା"
+    assert stem_word("ବଇଗୁଡ଼ିକ") == "ବଇ"
+    assert stem_word("କଲେ") == "କ"
+
+
+def test_stem_text():
+    text = "ପିଲାମାନେ ବଇଗୁଡ଼ିକ ପଢ଼ୁଛନ୍ତି"
+    assert stem_text(text) == "ପିଲା ବଇ ପଢ଼ୁଛ"
+


### PR DESCRIPTION
## Summary
- provide a rule‑based stemmer
- expose stemmer functions in package entry point
- document stemming usage in README and docs
- add test coverage for stemming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffe2cf84c832e906bdc9a0df677c6