### PR TITLE
[#193] Unicode normalize() and clean() for Odia text

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,37 @@ The tools are available in Odia language.
 - [x] [Google Translate](#translation)
 - [x] [Automatic extractive text summarization](#automatic-extractive-text-summarization)
 - [x] [Add Dictionary corpus](#offline-dictionary)
+- [x] [Unicode normalization & clean](#unicode-normalization)
+
+
+### :material-broom: Unicode normalization
+
+- The same visible Odia string can be encoded in many byte sequences (e.g. precomposed vs decomposed nukta `ଡ଼`, stray ZWJ/ZWNJ from copy-paste, Latin digits mixed in with Odia).
+- Normalize text before tokenizing, indexing, hashing, or comparing.
+
+```python
+from openodia import normalize, clean
+
+# Pure Unicode normalization (NFC / NFD / NFKC / NFKD)
+normalize("ଡ" + "଼")           # "ଡ଼"  (composed)
+normalize("ଡ଼", form="NFD")    # "ଡ" + "଼"  (decomposed)
+
+# Opinionated cleanup: NFC + strip ZWJ/ZWNJ + collapse whitespace
+clean("  ନମ‌ସ୍କାର   ଓଡ଼ିଆ  ")
+# "ନମସ୍କାର ଓଡ଼ିଆ"
+
+# Optional digit conversion (off by default)
+from openodia.text import CleanOptions
+clean("ଆଜି 123 ବର୍ଷ", options=CleanOptions(latin_to_odia_digits=True))
+# "ଆଜି ୧୨୩ ବର୍ଷ"
+
+clean("ଆଜି ୧୨୩ ବର୍ଷ", options=CleanOptions(odia_to_latin_digits=True))
+# "ଆଜି 123 ବର୍ଷ"
+```
+
+??? hint "`clean()` is idempotent"
+    `clean(clean(x)) == clean(x)` always holds, so it is safe to apply repeatedly
+    or sprinkle through a pipeline without compounding side-effects.
 
 
 ### :material-format-letter-case: Odia alphabets 

--- a/openodia/__init__.py
+++ b/openodia/__init__.py
@@ -8,14 +8,17 @@ from ._odianames import Names as name
 from ._summarization import WordFrequency
 from ._translate import odia_to_other_lang, other_lang_to_odia, universal_translation
 from ._understandData import UnderstandData as ud
+from .text import clean, normalize
 
 __all__ = [
     "alphabet",
+    "clean",
     "name",
-    "ud",
-    "other_lang_to_odia",
+    "normalize",
     "odia_to_other_lang",
+    "other_lang_to_odia",
+    "STOPWORDS",
+    "ud",
     "universal_translation",
     "WordFrequency",
-    "STOPWORDS",
 ]

--- a/openodia/text/__init__.py
+++ b/openodia/text/__init__.py
@@ -1,0 +1,25 @@
+"""Text normalization and cleanup utilities for Odia."""
+
+from openodia.text.normalize import (
+    ASCII_DIGITS,
+    DEFAULT_CLEAN,
+    ODIA_DIGITS,
+    ZWJ,
+    ZWNJ,
+    CleanOptions,
+    UnicodeForm,
+    clean,
+    normalize,
+)
+
+__all__ = [
+    "ASCII_DIGITS",
+    "DEFAULT_CLEAN",
+    "ODIA_DIGITS",
+    "ZWJ",
+    "ZWNJ",
+    "CleanOptions",
+    "UnicodeForm",
+    "clean",
+    "normalize",
+]

--- a/openodia/text/normalize.py
+++ b/openodia/text/normalize.py
@@ -1,0 +1,120 @@
+"""Unicode normalization and cleanup for Odia text.
+
+The functions here are *deterministic* and have no external dependencies.
+They are intended to be the first step of any text-processing pipeline.
+
+Typical usage:
+
+>>> from openodia import normalize, clean
+>>> normalize("ଡ଼")          # decomposed ଡ଼
+'ଡ଼'
+>>> clean("ନମ‌ସ୍କାର 123")  # strips ZWNJ, optionally converts digits
+'ନମସ୍କାର 123'
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from dataclasses import dataclass
+from typing import Literal
+
+UnicodeForm = Literal["NFC", "NFD", "NFKC", "NFKD"]
+
+# Zero-width joiners frequently appear as IME / copy-paste noise in Odia text.
+ZWJ: str = "‍"
+ZWNJ: str = "‌"
+
+# Digit blocks. Ordered ``0..9`` so ``str.translate`` tables map index-for-index.
+ASCII_DIGITS: str = "0123456789"
+ODIA_DIGITS: str = "୦୧୨୩୪୫୬୭୮୯"
+
+_LATIN_TO_ODIA_DIGITS = str.maketrans(ASCII_DIGITS, ODIA_DIGITS)
+_ODIA_TO_LATIN_DIGITS = str.maketrans(ODIA_DIGITS, ASCII_DIGITS)
+
+
+def normalize(text: str, form: UnicodeForm = "NFC") -> str:
+    """Return ``text`` in the requested Unicode normalization form.
+
+    Args:
+        text: Input string.
+        form: One of ``"NFC"``, ``"NFD"``, ``"NFKC"``, ``"NFKD"``.
+            Defaults to ``"NFC"`` (the right choice for Indic Unicode).
+
+    Returns:
+        The normalized string.
+
+    Raises:
+        ValueError: If ``form`` is not one of the four standard forms.
+    """
+    if form not in ("NFC", "NFD", "NFKC", "NFKD"):
+        raise ValueError(f"form must be one of NFC, NFD, NFKC, NFKD; got {form!r}")
+    return unicodedata.normalize(form, text)
+
+
+@dataclass(frozen=True)
+class CleanOptions:
+    """Options for :func:`clean`.
+
+    Attributes:
+        form: Unicode normalization form applied first. Defaults to ``"NFC"``.
+        strip_zwj: Drop zero-width joiner (U+200D).
+        strip_zwnj: Drop zero-width non-joiner (U+200C).
+        collapse_whitespace: Replace runs of whitespace with a single space
+            and trim leading/trailing whitespace.
+        latin_to_odia_digits: Convert ASCII digits ``0-9`` to Odia digits.
+        odia_to_latin_digits: Convert Odia digits ``୦-୯`` to ASCII digits.
+            Mutually exclusive with ``latin_to_odia_digits``.
+    """
+
+    form: UnicodeForm = "NFC"
+    strip_zwj: bool = True
+    strip_zwnj: bool = True
+    collapse_whitespace: bool = True
+    latin_to_odia_digits: bool = False
+    odia_to_latin_digits: bool = False
+
+    def __post_init__(self) -> None:
+        if self.latin_to_odia_digits and self.odia_to_latin_digits:
+            raise ValueError("latin_to_odia_digits and odia_to_latin_digits are mutually exclusive")
+
+
+DEFAULT_CLEAN: CleanOptions = CleanOptions()
+
+
+def clean(text: str, options: CleanOptions | None = None) -> str:
+    """Return ``text`` with common Odia-specific anomalies removed.
+
+    Always applied (unless disabled in ``options``):
+
+    * Unicode normalization (NFC by default).
+    * ZWJ / ZWNJ stripping.
+    * Whitespace collapsing.
+
+    Off by default:
+
+    * Latin ↔ Odia digit conversion.
+
+    Args:
+        text: Input string.
+        options: Cleanup configuration. ``None`` uses :data:`DEFAULT_CLEAN`.
+
+    Returns:
+        The cleaned string. ``clean(clean(x)) == clean(x)`` for any ``x``.
+    """
+    if options is None:
+        options = DEFAULT_CLEAN
+
+    out = normalize(text, options.form)
+
+    if options.strip_zwj:
+        out = out.replace(ZWJ, "")
+    if options.strip_zwnj:
+        out = out.replace(ZWNJ, "")
+    if options.latin_to_odia_digits:
+        out = out.translate(_LATIN_TO_ODIA_DIGITS)
+    if options.odia_to_latin_digits:
+        out = out.translate(_ODIA_TO_LATIN_DIGITS)
+    if options.collapse_whitespace:
+        out = " ".join(out.split())
+
+    return out

--- a/tests/test_text_normalize.py
+++ b/tests/test_text_normalize.py
@@ -1,0 +1,157 @@
+import unicodedata
+
+import pytest
+
+from openodia import clean, normalize
+from openodia.text import (
+    ASCII_DIGITS,
+    DEFAULT_CLEAN,
+    ODIA_DIGITS,
+    ZWJ,
+    ZWNJ,
+    CleanOptions,
+)
+
+
+class TestNormalize:
+    """Tests for :func:`openodia.normalize`."""
+
+    @pytest.mark.parametrize("form", ["NFC", "NFD", "NFKC", "NFKD"])
+    def test_accepts_all_four_standard_forms(self, form: str) -> None:
+        assert normalize("ଓଡ଼ିଆ", form=form) == unicodedata.normalize(form, "ଓଡ଼ିଆ")
+
+    def test_default_form_is_nfc(self) -> None:
+        decomposed = "ଡ" + "଼"
+        assert normalize(decomposed) == unicodedata.normalize("NFC", decomposed)
+
+    def test_nfc_composes_nukta(self) -> None:
+        decomposed = "ଡ" + "଼"
+        composed = "ଡ଼"
+        assert normalize(decomposed, form="NFC") == composed
+
+    def test_nfd_decomposes_nukta(self) -> None:
+        assert normalize("ଡ଼", form="NFD") == "ଡ" + "଼"
+
+    def test_idempotent_under_repeated_application(self) -> None:
+        text = "ନମସ୍କାର ଓଡ଼ିଆ"
+        once = normalize(text)
+        twice = normalize(once)
+        assert once == twice
+
+    def test_empty_string(self) -> None:
+        assert normalize("") == ""
+
+    def test_ascii_unchanged(self) -> None:
+        assert normalize("hello world 123") == "hello world 123"
+
+    def test_invalid_form_raises(self) -> None:
+        with pytest.raises(ValueError, match="form must be one of"):
+            normalize("ଓଡ଼ିଆ", form="NFX")  # type: ignore[arg-type]
+
+
+class TestCleanOptions:
+    def test_default_options_are_safe(self) -> None:
+        opts = CleanOptions()
+        assert opts.form == "NFC"
+        assert opts.strip_zwj is True
+        assert opts.strip_zwnj is True
+        assert opts.collapse_whitespace is True
+        assert opts.latin_to_odia_digits is False
+        assert opts.odia_to_latin_digits is False
+
+    def test_mutually_exclusive_digit_conversions(self) -> None:
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            CleanOptions(latin_to_odia_digits=True, odia_to_latin_digits=True)
+
+    def test_default_clean_singleton_matches_default_options(self) -> None:
+        assert DEFAULT_CLEAN == CleanOptions()
+
+
+class TestClean:
+    """Tests for :func:`openodia.clean`."""
+
+    def test_idempotent(self) -> None:
+        text = f" ନମ{ZWNJ}ସ୍କାର  {ZWJ}ଓଡ଼ିଆ  "
+        once = clean(text)
+        twice = clean(once)
+        assert once == twice
+
+    def test_strips_zwnj_by_default(self) -> None:
+        assert ZWNJ not in clean(f"ନମ{ZWNJ}ସ୍କାର")
+
+    def test_strips_zwj_by_default(self) -> None:
+        assert ZWJ not in clean(f"ନମ{ZWJ}ସ୍କାର")
+
+    def test_keep_zwj_when_disabled(self) -> None:
+        out = clean(
+            f"ନମ{ZWJ}ସ୍କାର",
+            options=CleanOptions(strip_zwj=False, strip_zwnj=False),
+        )
+        assert ZWJ in out
+
+    def test_collapses_whitespace_by_default(self) -> None:
+        assert clean("  ନମସ୍କାର    ଓଡ଼ିଆ  ") == "ନମସ୍କାର ଓଡ଼ିଆ"
+
+    def test_collapses_tabs_and_newlines(self) -> None:
+        assert clean("ନମସ୍କାର\t\nଓଡ଼ିଆ") == "ନମସ୍କାର ଓଡ଼ିଆ"
+
+    def test_keep_whitespace_when_disabled(self) -> None:
+        out = clean(
+            "  ନମସ୍କାର  ",
+            options=CleanOptions(collapse_whitespace=False),
+        )
+        assert out == "  ନମସ୍କାର  "
+
+    def test_normalizes_to_nfc_by_default(self) -> None:
+        decomposed = "ଡ" + "଼"
+        assert clean(decomposed) == "ଡ଼"
+
+    def test_latin_to_odia_digits(self) -> None:
+        out = clean(
+            "ଆଜି 123 ବର୍ଷ",
+            options=CleanOptions(latin_to_odia_digits=True),
+        )
+        assert out == "ଆଜି ୧୨୩ ବର୍ଷ"
+
+    def test_odia_to_latin_digits(self) -> None:
+        out = clean(
+            "ଆଜି ୧୨୩ ବର୍ଷ",
+            options=CleanOptions(odia_to_latin_digits=True),
+        )
+        assert out == "ଆଜି 123 ବର୍ଷ"
+
+    def test_default_does_not_convert_digits(self) -> None:
+        assert clean("123") == "123"
+        assert clean("୧୨୩") == "୧୨୩"
+
+    def test_empty_string(self) -> None:
+        assert clean("") == ""
+
+    def test_options_none_uses_default(self) -> None:
+        text = f" ନମ{ZWNJ}ସ୍କାର "
+        assert clean(text) == clean(text, options=None)
+
+
+class TestModuleConstants:
+    def test_digit_strings_are_aligned(self) -> None:
+        assert len(ASCII_DIGITS) == len(ODIA_DIGITS) == 10
+
+    def test_zwj_codepoint(self) -> None:
+        assert ord(ZWJ) == 0x200D
+
+    def test_zwnj_codepoint(self) -> None:
+        assert ord(ZWNJ) == 0x200C
+
+
+class TestPublicAPI:
+    """The user-facing aliases should exist on the top-level package."""
+
+    def test_normalize_is_exported(self) -> None:
+        import openodia
+
+        assert openodia.normalize is normalize
+
+    def test_clean_is_exported(self) -> None:
+        import openodia
+
+        assert openodia.clean is clean


### PR DESCRIPTION
Closes #193.

## What

Introduces `openodia.text` submodule with two pure-Python functions:

- **`normalize(text, form='NFC')`** — wraps `unicodedata.normalize` with validation. Accepts the four standard forms.
- **`clean(text, options=None)`** — opinionated cleanup:
  - NFC normalization (configurable)
  - ZWJ / ZWNJ stripping (on by default)
  - whitespace collapsing (on by default)
  - Latin ↔ Odia digit conversion (off by default; mutually-exclusive opt-ins)

Both are exposed at the top level as `openodia.normalize` and `openodia.clean`, matching the existing `alphabet` / `name` / `ud` alias style.

`CleanOptions` is a frozen dataclass; `DEFAULT_CLEAN` is the shared default instance.

## Acceptance criteria

- [x] `openodia.text.normalize(s)` returns `unicodedata.normalize("NFC", s)` by default.
- [x] `openodia.text.clean(s)` strips ZWJ/ZWNJ and collapses whitespace.
- [x] Latin↔Odia digit conversion exposed via `CleanOptions`.
- [x] Confusables exposed as module constants (`ASCII_DIGITS`, `ODIA_DIGITS`, `ZWJ`, `ZWNJ`).
- [x] Tests cover precomposed-vs-decomposed nukta, ZWJ/ZWNJ stripping, Latin-digit conversion, idempotence (`clean(clean(x)) == clean(x)`).

## Tests & coverage

```
tests/test_text_normalize.py ................................   [100%]
32 passed in 1.01s

Name                         Stmts   Miss  Cover
-------------------------------------------------
openodia/text/__init__.py        2      0   100%
openodia/text/normalize.py      42      0   100%
-------------------------------------------------
TOTAL                           44      0   100%
```

Full suite: **207 passed** (175 existing + 32 new). No regressions.

## Backward compatibility

Pure addition. No existing API changed.

## Docs

`docs/index.md` updated with a "Unicode normalization" section showing both functions and the `CleanOptions` opt-ins.

## Notes for review

- Per the maintainer's direction the full scope of the issue is included (clean + ZWJ/ZWNJ + digit confusables) — not split into a follow-up.
- I have **not** modified any existing module internally; `clean()` is a new entry point users opt into. A later PR can wire it into `dictionary` / `word_tokenizer` once we agree on the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)