### PR TITLE
[#198] Numbers, ordinals, currency, dates → Odia words (+ digit converter)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ The tools are available in Odia language.
 - [x] [Unicode normalization & clean](#unicode-normalization)
 - [x] [Corpus statistics](#corpus-statistics)
 - [x] [Syllabifier (akshara)](#syllabifier)
+- [x] [Numbers, dates, and currency in words](#numbers-and-words)
 
 
 ### :material-broom: Unicode normalization
@@ -159,6 +160,55 @@ syllable.hyphenate("ନମସ୍କାର ଓଡ଼ିଆ", separator="·")
 ??? note "Round-trip property"
     `"".join(syllable.split(word)) == word` for any input — the splitter
     is a strict tokeniser, never modifying or normalising characters.
+
+### :material-numeric: Numbers and words
+
+- Convert between integers and Odia words, in both **Indian** (lakh / crore) and **short** (million / billion / trillion) numbering scales.
+- Verbalise dates, currency amounts, and ordinals.
+- Bidirectional Odia ↔ ASCII digit conversion.
+
+```python
+from openodia import numbers
+
+# Cardinal numbers
+numbers.to_words(1234)
+# 'ଏକ ହଜାର ଦୁଇ ଶହ ଚଉତିରିଶ'
+
+numbers.to_words(12_34_567)            # Indian: lakh / crore
+# 'ବାର ଲକ୍ଷ ଚଉତିରିଶ ହଜାର ପାଞ୍ଚ ଶହ ସତଷଠି'
+
+numbers.to_words(1_000_000, scale="short")
+# 'ଏକ ମିଲିୟନ'
+
+numbers.to_words(-100)
+# 'ଋଣାତ୍ମକ ଏକ ଶହ'
+
+# Reverse direction
+numbers.from_words("ଏକ ହଜାର ଦୁଇ ଶହ ଚଉତିରିଶ")  # 1234
+
+# Ordinals (1..10 irregular, 11+ uses 'ତମ' suffix)
+numbers.to_ordinal(3)          # 'ତୃତୀୟ'
+numbers.to_ordinal(11)         # 'ଏଗାରତମ'
+
+# Currency
+numbers.to_words_currency(1500.50)
+# 'ଏକ ହଜାର ପାଞ୍ଚ ଶହ ଟଙ୍କା ପଚାଶ ପଇସା'
+
+# Date verbalisation
+from datetime import date
+numbers.to_words_date(date(2026, 5, 27))
+# '<day ordinal> ମଇ, ଦୁଇ ହଜାର ଛବିଶ'
+
+# Digit conversion
+numbers.ascii_to_odia("2026")   # '୨୦୨୬'
+numbers.odia_to_ascii("୨୦୨୬")   # '2026'
+```
+
+??? note "Number words 0..99"
+    The Odia counting table below 100 lives at `openodia/numbers/_tables.py`
+    as a single tuple of length 100. Native-speaker corrections land there
+    and are picked up by every API in this module automatically.
+
 
 ### :material-format-letter-case: Odia alphabets 
 

--- a/openodia/__init__.py
+++ b/openodia/__init__.py
@@ -8,6 +8,7 @@ from ._odianames import Names as name
 from ._summarization import WordFrequency
 from ._translate import odia_to_other_lang, other_lang_to_odia, universal_translation
 from ._understandData import UnderstandData as ud
+from . import numbers
 from . import syllable
 from .stats import FreqDist, collocations, cooccurrence, ngrams
 from .stopwords import Stopwords
@@ -22,6 +23,7 @@ __all__ = [
     "name",
     "ngrams",
     "normalize",
+    "numbers",
     "odia_to_other_lang",
     "other_lang_to_odia",
     "STOPWORDS",

--- a/openodia/numbers/__init__.py
+++ b/openodia/numbers/__init__.py
@@ -1,0 +1,28 @@
+"""Number ↔ words, digit conversion, currency, and date verbalization for Odia.
+
+Examples:
+    >>> from openodia import numbers
+    >>> numbers.to_words(1234)
+    'ଏକ ହଜାର ଦୁଇ ଶହ ଚଉତିରିଶ'
+    >>> numbers.ascii_to_odia("2026")
+    '୨୦୨୬'
+    >>> numbers.to_ordinal(3)
+    'ତୃତୀୟ'
+"""
+
+from openodia.numbers._currency import to_words_currency
+from openodia.numbers._dates import to_words_date
+from openodia.numbers._digits import ascii_to_odia, odia_to_ascii
+from openodia.numbers._ordinals import to_ordinal
+from openodia.numbers._words import NumberingScale, from_words, to_words
+
+__all__ = [
+    "NumberingScale",
+    "ascii_to_odia",
+    "from_words",
+    "odia_to_ascii",
+    "to_ordinal",
+    "to_words",
+    "to_words_currency",
+    "to_words_date",
+]

--- a/openodia/numbers/_currency.py
+++ b/openodia/numbers/_currency.py
@@ -1,0 +1,68 @@
+"""Currency-amount verbalization."""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+from openodia.numbers._tables import CURRENCY_PAISA, CURRENCY_RUPEE
+from openodia.numbers._words import NumberingScale, to_words
+
+
+def to_words_currency(
+    amount: float | Decimal | int,
+    currency: str = "INR",
+    scale: NumberingScale = "indian",
+) -> str:
+    """Verbalize a monetary amount in Odia.
+
+    Args:
+        amount: Numeric value. Fractional part is rounded to two decimal
+            places (paisa) using banker-friendly half-up rounding.
+        currency: Currently only ``"INR"`` is supported. Defined as a
+            parameter so additional currencies can be added without a
+            breaking change.
+        scale: Numbering scale to use for both rupee and paisa parts.
+
+    Returns:
+        For non-zero rupees and non-zero paisa::
+
+            "<rupee_words> ଟଙ୍କା <paisa_words> ପଇସା"
+
+        For zero paisa, the paisa half is omitted. For zero rupees and
+        non-zero paisa, the rupee half is omitted.
+
+    Raises:
+        ValueError: If ``amount`` is negative or ``currency`` is not
+            supported.
+
+    Examples:
+        >>> to_words_currency(1500.50)
+        'ଏକ ହଜାର ପାଞ୍ଚ ଶହ ଟଙ୍କା ପଚାଶ ପଇସା'
+        >>> to_words_currency(1)
+        'ଏକ ଟଙ୍କା'
+        >>> to_words_currency(0.05)
+        'ପାଞ୍ଚ ପଇସା'
+    """
+    if currency != "INR":
+        raise ValueError(f"unsupported currency {currency!r}; supported: 'INR'")
+
+    decimal = Decimal(str(amount))
+    if decimal < 0:
+        raise ValueError(f"amount must be >= 0, got {amount}")
+
+    rupees_dec, paisa_dec = divmod(
+        (decimal * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP),
+        100,
+    )
+    rupees = int(rupees_dec)
+    paisa = int(paisa_dec)
+
+    parts: list[str] = []
+    if rupees > 0:
+        parts.append(f"{to_words(rupees, scale=scale)} {CURRENCY_RUPEE}")
+    if paisa > 0:
+        parts.append(f"{to_words(paisa, scale=scale)} {CURRENCY_PAISA}")
+    if not parts:
+        # Zero rupees and zero paisa.
+        return f"{to_words(0, scale=scale)} {CURRENCY_RUPEE}"
+    return " ".join(parts)

--- a/openodia/numbers/_dates.py
+++ b/openodia/numbers/_dates.py
@@ -1,0 +1,37 @@
+"""Date verbalization."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from openodia.numbers._ordinals import to_ordinal
+from openodia.numbers._tables import GREGORIAN_MONTHS
+from openodia.numbers._words import NumberingScale, to_words
+
+
+def to_words_date(value: date, scale: NumberingScale = "indian") -> str:
+    """Verbalize a Gregorian date in Odia.
+
+    Output format: ``"<day_ordinal> <month_name>, <year_words>"``.
+
+    Args:
+        value: A :class:`datetime.date` (or :class:`datetime.datetime`).
+        scale: Numbering scale for the year portion.
+
+    Returns:
+        Space-separated Odia string.
+
+    Raises:
+        ValueError: If ``value.year`` is non-positive.
+
+    Examples:
+        >>> from datetime import date
+        >>> to_words_date(date(2026, 5, 27))
+        'ସତାଇଶତମ ମଇ, ଦୁଇ ହଜାର ଛବିଶ'
+    """
+    if value.year < 1:
+        raise ValueError(f"year must be >= 1, got {value.year}")
+    day_word = to_ordinal(value.day)
+    month_word = GREGORIAN_MONTHS[value.month - 1]
+    year_word = to_words(value.year, scale=scale)
+    return f"{day_word} {month_word}, {year_word}"

--- a/openodia/numbers/_digits.py
+++ b/openodia/numbers/_digits.py
@@ -1,0 +1,19 @@
+"""Odia ↔ ASCII digit conversion."""
+
+from __future__ import annotations
+
+ASCII_DIGITS: str = "0123456789"
+ODIA_DIGITS: str = "୦୧୨୩୪୫୬୭୮୯"
+
+_ASCII_TO_ODIA = str.maketrans(ASCII_DIGITS, ODIA_DIGITS)
+_ODIA_TO_ASCII = str.maketrans(ODIA_DIGITS, ASCII_DIGITS)
+
+
+def ascii_to_odia(text: str) -> str:
+    """Convert ASCII digits in ``text`` to Odia digits. Non-digits pass through."""
+    return text.translate(_ASCII_TO_ODIA)
+
+
+def odia_to_ascii(text: str) -> str:
+    """Convert Odia digits in ``text`` to ASCII digits. Non-digits pass through."""
+    return text.translate(_ODIA_TO_ASCII)

--- a/openodia/numbers/_ordinals.py
+++ b/openodia/numbers/_ordinals.py
@@ -1,0 +1,25 @@
+"""Ordinal forms in Odia."""
+
+from __future__ import annotations
+
+from openodia.numbers._tables import ORDINAL_SUFFIX, ORDINALS_IRREGULAR
+from openodia.numbers._words import to_words
+
+
+def to_ordinal(n: int) -> str:
+    """Return the ordinal Odia word for the positive integer ``n``.
+
+    Ordinals 1..10 use their irregular forms (ପ୍ରଥମ, ଦ୍ୱିତୀୟ, ...).
+    For n ≥ 11 the cardinal word is suffixed with ``ତମ``.
+
+    Args:
+        n: Positive integer.
+
+    Raises:
+        ValueError: If ``n`` is zero or negative.
+    """
+    if n < 1:
+        raise ValueError(f"ordinals are defined for n >= 1, got {n}")
+    if n in ORDINALS_IRREGULAR:
+        return ORDINALS_IRREGULAR[n]
+    return f"{to_words(n)}{ORDINAL_SUFFIX}"

--- a/openodia/numbers/_tables.py
+++ b/openodia/numbers/_tables.py
@@ -1,0 +1,169 @@
+"""Lookup tables for Odia number words.
+
+The 0..99 list below is the package's single source of truth for irregular
+Odia counts. Any correction by a native-speaker reviewer should land here
+and be reflected in :func:`openodia.numbers.to_words` automatically.
+"""
+
+from __future__ import annotations
+
+# Numbers 0..99 in their standard Odia forms.
+# Index N is the word for the integer N.
+UNDER_HUNDRED: tuple[str, ...] = (
+    "ଶୂନ୍ୟ",  # 0
+    "ଏକ",  # 1
+    "ଦୁଇ",  # 2
+    "ତିନି",  # 3
+    "ଚାରି",  # 4
+    "ପାଞ୍ଚ",  # 5
+    "ଛଅ",  # 6
+    "ସାତ",  # 7
+    "ଆଠ",  # 8
+    "ନଅ",  # 9
+    "ଦଶ",  # 10
+    "ଏଗାର",  # 11
+    "ବାର",  # 12
+    "ତେର",  # 13
+    "ଚଉଦ",  # 14
+    "ପନ୍ଦର",  # 15
+    "ଷୋହଳ",  # 16
+    "ସତର",  # 17
+    "ଅଠର",  # 18
+    "ଊଣେଇଶ",  # 19
+    "କୋଡ଼ିଏ",  # 20
+    "ଏକୋଇଶ",  # 21
+    "ବାଇଶ",  # 22
+    "ତେଇଶ",  # 23
+    "ଚବିଶ",  # 24
+    "ପଚିଶ",  # 25
+    "ଛବିଶ",  # 26
+    "ସତାଇଶ",  # 27
+    "ଅଠାଇଶ",  # 28
+    "ଅଣତିରିଶ",  # 29
+    "ତିରିଶ",  # 30
+    "ଏକତିରିଶ",  # 31
+    "ବତିଶ",  # 32
+    "ତେତିଶ",  # 33
+    "ଚଉତିରିଶ",  # 34
+    "ପଇଁତିରିଶ",  # 35
+    "ଛତିଶ",  # 36
+    "ସଇଁତିରିଶ",  # 37
+    "ଅଠତିରିଶ",  # 38
+    "ଅଣଚାଳିଶ",  # 39
+    "ଚାଳିଶ",  # 40
+    "ଏକଚାଳିଶ",  # 41
+    "ବୟାଳିଶ",  # 42
+    "ତେୟାଳିଶ",  # 43
+    "ଚଉରାଳିଶ",  # 44
+    "ପଞ୍ଚଚାଳିଶ",  # 45
+    "ଛୟାଳିଶ",  # 46
+    "ସତଚାଳିଶ",  # 47
+    "ଅଠଚାଳିଶ",  # 48
+    "ଅଣଚାଶ",  # 49
+    "ପଚାଶ",  # 50
+    "ଏକାବନ",  # 51
+    "ବାବନ",  # 52
+    "ତେପନ",  # 53
+    "ଚଉପନ",  # 54
+    "ପଞ୍ଚାବନ",  # 55
+    "ଛପନ",  # 56
+    "ସତାବନ",  # 57
+    "ଅଠାବନ",  # 58
+    "ଅଣଷଠି",  # 59
+    "ଷାଠିଏ",  # 60
+    "ଏକଷଠି",  # 61
+    "ବାଷଠି",  # 62
+    "ତେଷଠି",  # 63
+    "ଚଉଷଠି",  # 64
+    "ପଞ୍ଚଷଠି",  # 65
+    "ଛଅଷଠି",  # 66
+    "ସତଷଠି",  # 67
+    "ଅଠଷଠି",  # 68
+    "ଅଣସତୁରୀ",  # 69
+    "ସତୁରୀ",  # 70
+    "ଏକସତୁରୀ",  # 71
+    "ବାସତୁରୀ",  # 72
+    "ତେସତୁରୀ",  # 73
+    "ଚଉସତୁରୀ",  # 74
+    "ପଞ୍ଚସତୁରୀ",  # 75
+    "ଛଅସତୁରୀ",  # 76
+    "ସତସତୁରୀ",  # 77
+    "ଅଠସତୁରୀ",  # 78
+    "ଅଣାଅଶି",  # 79
+    "ଅଶୀ",  # 80
+    "ଏକାଅଶି",  # 81
+    "ବାଆଶି",  # 82
+    "ତିରାଅଶି",  # 83
+    "ଚଉରାଅଶି",  # 84
+    "ପଞ୍ଚାଅଶି",  # 85
+    "ଛଅଆଶି",  # 86
+    "ସତାଅଶି",  # 87
+    "ଅଠାଅଶି",  # 88
+    "ଅଣେଇଶ",  # 89
+    "ନବେ",  # 90
+    "ଏକାନବେ",  # 91
+    "ବାନେ",  # 92
+    "ତିରାନେ",  # 93
+    "ଚଉରାନେ",  # 94
+    "ପଞ୍ଚାନେ",  # 95
+    "ଛଅନେ",  # 96
+    "ସତାନେ",  # 97
+    "ଅଠାନେ",  # 98
+    "ଅନେଶ",  # 99
+)
+
+# Place-value multipliers in increasing order. Used by the composition
+# algorithm: walk multipliers high → low, divmod at each step.
+INDIAN_MULTIPLIERS: tuple[tuple[int, str], ...] = (
+    (10**7, "କୋଟି"),  # crore
+    (10**5, "ଲକ୍ଷ"),  # lakh
+    (1_000, "ହଜାର"),  # thousand
+    (100, "ଶହ"),  # hundred
+)
+
+SHORT_MULTIPLIERS: tuple[tuple[int, str], ...] = (
+    (10**12, "ଟ୍ରିଲିୟନ"),  # trillion
+    (10**9, "ବିଲିୟନ"),  # billion
+    (10**6, "ମିଲିୟନ"),  # million
+    (1_000, "ହଜାର"),  # thousand
+    (100, "ଶହ"),  # hundred
+)
+
+# Irregular ordinals (1st..10th); higher ordinals are formed by suffixing
+# ``ତମ`` to the cardinal form.
+ORDINALS_IRREGULAR: dict[int, str] = {
+    1: "ପ୍ରଥମ",
+    2: "ଦ୍ୱିତୀୟ",
+    3: "ତୃତୀୟ",
+    4: "ଚତୁର୍ଥ",
+    5: "ପଞ୍ଚମ",
+    6: "ଷଷ୍ଠ",
+    7: "ସପ୍ତମ",
+    8: "ଅଷ୍ଟମ",
+    9: "ନବମ",
+    10: "ଦଶମ",
+}
+ORDINAL_SUFFIX: str = "ତମ"
+
+# Words used in compound output.
+NEGATIVE_WORD: str = "ଋଣାତ୍ମକ"
+
+# Currency vocabulary.
+CURRENCY_RUPEE: str = "ଟଙ୍କା"
+CURRENCY_PAISA: str = "ପଇସା"
+
+# Month names — Gregorian, transliterated. Keep simple.
+GREGORIAN_MONTHS: tuple[str, ...] = (
+    "ଜାନୁଆରୀ",
+    "ଫେବ୍ରୁଆରୀ",
+    "ମାର୍ଚ୍ଚ",
+    "ଏପ୍ରିଲ",
+    "ମଇ",
+    "ଜୁନ",
+    "ଜୁଲାଇ",
+    "ଅଗଷ୍ଟ",
+    "ସେପ୍ଟେମ୍ବର",
+    "ଅକ୍ଟୋବର",
+    "ନଭେମ୍ବର",
+    "ଡିସେମ୍ବର",
+)

--- a/openodia/numbers/_words.py
+++ b/openodia/numbers/_words.py
@@ -1,0 +1,135 @@
+"""Integer ↔ words conversion."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from openodia.numbers._tables import (
+    INDIAN_MULTIPLIERS,
+    NEGATIVE_WORD,
+    SHORT_MULTIPLIERS,
+    UNDER_HUNDRED,
+)
+
+NumberingScale = Literal["indian", "short"]
+
+
+def to_words(n: int, scale: NumberingScale = "indian") -> str:
+    """Convert an integer to its Odia word form.
+
+    Args:
+        n: Any integer (positive, zero, or negative).
+        scale: ``"indian"`` (default) uses lakh / crore. ``"short"`` uses
+            million / billion / trillion.
+
+    Returns:
+        Space-separated Odia words.
+
+    Raises:
+        ValueError: If ``scale`` is not one of the two supported values.
+
+    Examples:
+        >>> to_words(0)
+        'ଶୂନ୍ୟ'
+        >>> to_words(1234)
+        'ଏକ ହଜାର ଦୁଇ ଶହ ଚଉତିରିଶ'
+        >>> to_words(1_000_000, scale="short")
+        'ଏକ ମିଲିୟନ'
+    """
+    if scale == "indian":
+        multipliers = INDIAN_MULTIPLIERS
+    elif scale == "short":
+        multipliers = SHORT_MULTIPLIERS
+    else:
+        raise ValueError(f"unknown scale {scale!r}; supported: 'indian', 'short'")
+
+    if n < 0:
+        return f"{NEGATIVE_WORD} {_compose(-n, multipliers)}"
+    return _compose(n, multipliers)
+
+
+def _compose(n: int, multipliers: tuple[tuple[int, str], ...]) -> str:
+    """Build the word for a non-negative integer using the given multipliers."""
+    if n < 100:
+        return UNDER_HUNDRED[n]
+
+    parts: list[str] = []
+    remainder = n
+    for value, word in multipliers:
+        if remainder >= value:
+            quotient, remainder = divmod(remainder, value)
+            parts.append(f"{_compose(quotient, multipliers)} {word}")
+
+    if remainder > 0:
+        parts.append(UNDER_HUNDRED[remainder])
+
+    return " ".join(parts)
+
+
+def from_words(words: str, scale: NumberingScale = "indian") -> int:
+    """Parse an Odia number-words string back to an integer.
+
+    The inverse of :func:`to_words`. Accepts the output produced by this
+    package; tolerates extra whitespace.
+
+    Args:
+        words: Odia number-words string.
+        scale: Must match the scale used to produce ``words``.
+
+    Returns:
+        The integer value.
+
+    Raises:
+        ValueError: If a token is not recognised, if ``scale`` is invalid,
+            or if ``words`` is empty after stripping.
+
+    Examples:
+        >>> from_words("ଏକ ହଜାର ଦୁଇ ଶହ ଚଉତିରିଶ")
+        1234
+    """
+    if scale == "indian":
+        multipliers = INDIAN_MULTIPLIERS
+    elif scale == "short":
+        multipliers = SHORT_MULTIPLIERS
+    else:
+        raise ValueError(f"unknown scale {scale!r}; supported: 'indian', 'short'")
+
+    tokens = words.split()
+    if not tokens:
+        raise ValueError("empty input")
+
+    sign = 1
+    if tokens[0] == NEGATIVE_WORD:
+        sign = -1
+        tokens = tokens[1:]
+        if not tokens:
+            raise ValueError("missing magnitude after negative marker")
+
+    # "ଶହ" (hundred) is intra-group — it combines with the running unit
+    # accumulator without closing the group. Larger multipliers (ହଜାର,
+    # ଲକ୍ଷ, କୋଟି, ମିଲିୟନ, ...) close the group and add to the total.
+    group_terminators = {word: value for value, word in multipliers if value >= 1000}
+    hundred_word = next((word for value, word in multipliers if value == 100), None)
+    word_to_int = {word: i for i, word in enumerate(UNDER_HUNDRED)}
+
+    total = 0
+    group = 0
+    current = 0
+    for token in tokens:
+        if token == hundred_word:
+            coefficient = current if current else 1
+            group += coefficient * 100
+            current = 0
+        elif token in group_terminators:
+            # Close the current group: (group + current) is the coefficient
+            # for this multiplier, e.g. "two hundred thirty-four thousand".
+            coefficient = (group + current) if (group + current) else 1
+            total += coefficient * group_terminators[token]
+            group = 0
+            current = 0
+        elif token in word_to_int:
+            current += word_to_int[token]
+        else:
+            raise ValueError(f"unrecognised token: {token!r}")
+
+    return sign * (total + group + current)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -1,0 +1,267 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from openodia import numbers
+from openodia.numbers._tables import UNDER_HUNDRED
+
+
+class TestDigitConversion:
+    @pytest.mark.parametrize(
+        "ascii_text, odia_text",
+        [
+            ("0", "୦"),
+            ("1", "୧"),
+            ("9", "୯"),
+            ("123", "୧୨୩"),
+            ("2026", "୨୦୨୬"),
+            ("", ""),
+        ],
+    )
+    def test_ascii_to_odia(self, ascii_text: str, odia_text: str) -> None:
+        assert numbers.ascii_to_odia(ascii_text) == odia_text
+
+    @pytest.mark.parametrize(
+        "ascii_text, odia_text",
+        [
+            ("0", "୦"),
+            ("123", "୧୨୩"),
+            ("2026", "୨୦୨୬"),
+            ("", ""),
+        ],
+    )
+    def test_odia_to_ascii(self, ascii_text: str, odia_text: str) -> None:
+        assert numbers.odia_to_ascii(odia_text) == ascii_text
+
+    def test_non_digits_pass_through(self) -> None:
+        # The Odia letter "ନ" is not a digit and must survive both directions.
+        assert numbers.ascii_to_odia("ନ123") == "ନ୧୨୩"
+        assert numbers.odia_to_ascii("ନ୧୨୩") == "ନ123"
+
+    def test_mixed_input_unchanged_in_both_directions(self) -> None:
+        """Non-target digits in the input pass through."""
+        assert numbers.ascii_to_odia("୧2") == "୧୨"  # Odia '୧' stays, '2' becomes '୨'
+        assert numbers.odia_to_ascii("1୨") == "12"  # ASCII '1' stays, '୨' becomes '2'
+
+    def test_round_trip(self) -> None:
+        for x in ["0", "9876543210", "123 456"]:
+            assert numbers.odia_to_ascii(numbers.ascii_to_odia(x)) == x
+
+
+class TestToWords:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (0, "ଶୂନ୍ୟ"),
+            (1, "ଏକ"),
+            (9, "ନଅ"),
+            (10, "ଦଶ"),
+            (15, "ପନ୍ଦର"),
+            (20, "କୋଡ଼ିଏ"),
+            (50, "ପଚାଶ"),
+            (99, "ଅନେଶ"),
+        ],
+    )
+    def test_under_hundred(self, value: int, expected: str) -> None:
+        assert numbers.to_words(value) == expected
+
+    def test_one_hundred(self) -> None:
+        assert numbers.to_words(100) == "ଏକ ଶହ"
+
+    def test_two_hundred_thirty_four(self) -> None:
+        assert numbers.to_words(234) == "ଦୁଇ ଶହ ଚଉତିରିଶ"
+
+    def test_one_thousand_two_hundred_thirty_four(self) -> None:
+        assert numbers.to_words(1234) == "ଏକ ହଜାର ଦୁଇ ଶହ ଚଉତିରିଶ"
+
+    def test_lakh(self) -> None:
+        # 12,34,567 in Indian numbering
+        assert numbers.to_words(12_34_567) == "ବାର ଲକ୍ଷ ଚଉତିରିଶ ହଜାର ପାଞ୍ଚ ଶହ ସତଷଠି"
+
+    def test_crore(self) -> None:
+        # 1,00,00,000 = one crore
+        assert numbers.to_words(1_00_00_000) == "ଏକ କୋଟି"
+
+    def test_two_crore_three_lakh(self) -> None:
+        assert numbers.to_words(2_03_00_000) == "ଦୁଇ କୋଟି ତିନି ଲକ୍ଷ"
+
+    def test_negative_number(self) -> None:
+        assert numbers.to_words(-5) == "ଋଣାତ୍ମକ ପାଞ୍ଚ"
+        assert numbers.to_words(-100) == "ଋଣାତ୍ମକ ଏକ ଶହ"
+
+    def test_short_scale_million(self) -> None:
+        assert numbers.to_words(1_000_000, scale="short") == "ଏକ ମିଲିୟନ"
+
+    def test_short_scale_billion(self) -> None:
+        assert numbers.to_words(1_000_000_000, scale="short") == "ଏକ ବିଲିୟନ"
+
+    def test_short_scale_trillion(self) -> None:
+        assert numbers.to_words(1_000_000_000_000, scale="short") == "ଏକ ଟ୍ରିଲିୟନ"
+
+    def test_short_scale_composes(self) -> None:
+        # 1,234,567 short scale: 1 million, 234 thousand, 5 hundred sixty-seven
+        assert numbers.to_words(1_234_567, scale="short") == "ଏକ ମିଲିୟନ ଦୁଇ ଶହ ଚଉତିରିଶ ହଜାର ପାଞ୍ଚ ଶହ ସତଷଠି"
+
+    def test_invalid_scale_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown scale"):
+            numbers.to_words(1, scale="long")  # type: ignore[arg-type]
+
+    def test_zero_in_both_scales(self) -> None:
+        assert numbers.to_words(0, scale="indian") == "ଶୂନ୍ୟ"
+        assert numbers.to_words(0, scale="short") == "ଶୂନ୍ୟ"
+
+
+class TestFromWords:
+    @pytest.mark.parametrize("n", [0, 1, 99, 100, 234, 1234, 12_34_567])
+    def test_round_trip_indian(self, n: int) -> None:
+        assert numbers.from_words(numbers.to_words(n)) == n
+
+    @pytest.mark.parametrize("n", [0, 1_000_000, 1_234_567, 1_000_000_000_000])
+    def test_round_trip_short(self, n: int) -> None:
+        assert numbers.from_words(numbers.to_words(n, scale="short"), scale="short") == n
+
+    def test_negative_round_trip(self) -> None:
+        for n in [-1, -100, -1234]:
+            assert numbers.from_words(numbers.to_words(n)) == n
+
+    def test_extra_whitespace_tolerated(self) -> None:
+        assert numbers.from_words("  ଏକ   ହଜାର   ") == 1000
+
+    def test_unrecognised_token_raises(self) -> None:
+        with pytest.raises(ValueError, match="unrecognised token"):
+            numbers.from_words("ଏକ flarble")
+
+    def test_empty_input_raises(self) -> None:
+        with pytest.raises(ValueError, match="empty input"):
+            numbers.from_words("")
+        with pytest.raises(ValueError, match="empty input"):
+            numbers.from_words("   ")
+
+    def test_negative_without_magnitude_raises(self) -> None:
+        with pytest.raises(ValueError, match="missing magnitude"):
+            numbers.from_words("ଋଣାତ୍ମକ")
+
+    def test_invalid_scale_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown scale"):
+            numbers.from_words("ଏକ", scale="long")  # type: ignore[arg-type]
+
+    def test_bare_multiplier_treated_as_one(self) -> None:
+        """`ଶହ` alone should mean 100."""
+        assert numbers.from_words("ଶହ") == 100
+        assert numbers.from_words("ହଜାର") == 1000
+
+
+class TestOrdinal:
+    @pytest.mark.parametrize(
+        "n, expected",
+        [
+            (1, "ପ୍ରଥମ"),
+            (2, "ଦ୍ୱିତୀୟ"),
+            (3, "ତୃତୀୟ"),
+            (4, "ଚତୁର୍ଥ"),
+            (5, "ପଞ୍ଚମ"),
+            (6, "ଷଷ୍ଠ"),
+            (7, "ସପ୍ତମ"),
+            (8, "ଅଷ୍ଟମ"),
+            (9, "ନବମ"),
+            (10, "ଦଶମ"),
+        ],
+    )
+    def test_irregular_ordinals(self, n: int, expected: str) -> None:
+        assert numbers.to_ordinal(n) == expected
+
+    def test_regular_ordinal_uses_tam_suffix(self) -> None:
+        assert numbers.to_ordinal(11) == f"{UNDER_HUNDRED[11]}ତମ"
+        assert numbers.to_ordinal(100) == "ଏକ ଶହତମ"
+
+    def test_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="ordinals are defined"):
+            numbers.to_ordinal(0)
+
+    def test_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="ordinals are defined"):
+            numbers.to_ordinal(-1)
+
+
+class TestCurrency:
+    def test_integer_rupees(self) -> None:
+        assert numbers.to_words_currency(1) == "ଏକ ଟଙ୍କା"
+        assert numbers.to_words_currency(1500) == "ଏକ ହଜାର ପାଞ୍ଚ ଶହ ଟଙ୍କା"
+
+    def test_with_paisa(self) -> None:
+        assert numbers.to_words_currency(1500.50) == "ଏକ ହଜାର ପାଞ୍ଚ ଶହ ଟଙ୍କା ପଚାଶ ପଇସା"
+
+    def test_paisa_only(self) -> None:
+        assert numbers.to_words_currency(0.05) == "ପାଞ୍ଚ ପଇସା"
+        assert numbers.to_words_currency(0.50) == "ପଚାଶ ପଇସା"
+
+    def test_zero_amount(self) -> None:
+        assert numbers.to_words_currency(0) == "ଶୂନ୍ୟ ଟଙ୍କା"
+        assert numbers.to_words_currency(0.00) == "ଶୂନ୍ୟ ଟଙ୍କା"
+
+    def test_rounding(self) -> None:
+        # 1.005 → 1.01 (half-up)
+        assert numbers.to_words_currency(1.005) == "ଏକ ଟଙ୍କା ଏକ ପଇସା"
+
+    def test_decimal_input_accepted(self) -> None:
+        assert numbers.to_words_currency(Decimal("100.25")) == "ଏକ ଶହ ଟଙ୍କା ପଚିଶ ପଇସା"
+
+    def test_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="amount must be >= 0"):
+            numbers.to_words_currency(-1)
+
+    def test_unsupported_currency_raises(self) -> None:
+        with pytest.raises(ValueError, match="unsupported currency"):
+            numbers.to_words_currency(1, currency="USD")
+
+
+class TestDate:
+    def test_basic(self) -> None:
+        # 27 May 2026
+        result = numbers.to_words_date(date(2026, 5, 27))
+        # day ordinal -> regular ordinal with suffix; month = ମଇ; year = ଦୁଇ ହଜାର ଛବିଶ
+        assert "ମଇ" in result
+        assert "ଦୁଇ ହଜାର ଛବିଶ" in result
+        assert result.endswith("ଦୁଇ ହଜାର ଛବିଶ")
+
+    def test_irregular_day_ordinal(self) -> None:
+        # 1st of any month should use the irregular ordinal.
+        result = numbers.to_words_date(date(2026, 1, 1))
+        assert result.startswith("ପ୍ରଥମ ")
+
+    def test_each_month_translated(self) -> None:
+        # Confirm the table covers all 12 months without crashing.
+        for month in range(1, 13):
+            numbers.to_words_date(date(2026, month, 15))
+
+    def test_year_zero_raises(self) -> None:
+        """``date`` rejects year 0 in its ctor, so we exercise the guard via a stub."""
+
+        class _StubDate:
+            year = 0
+            month = 1
+            day = 1
+
+        with pytest.raises(ValueError, match="year must be >= 1"):
+            numbers.to_words_date(_StubDate())  # type: ignore[arg-type]
+
+
+class TestPublicAPI:
+    def test_top_level_namespace(self) -> None:
+        import openodia
+
+        assert openodia.numbers is numbers
+        assert openodia.numbers.to_words(1) == "ଏକ"
+        assert openodia.numbers.from_words("ଏକ") == 1
+
+
+class TestTableSanity:
+    """Guard rails against accidental edits of the lookup tables."""
+
+    def test_under_hundred_has_100_entries(self) -> None:
+        assert len(UNDER_HUNDRED) == 100
+
+    def test_under_hundred_all_unique(self) -> None:
+        # If any two words are equal, from_words would round-trip wrong.
+        assert len(set(UNDER_HUNDRED)) == 100


### PR DESCRIPTION
Closes #198. Full scope per maintainer direction — Indian and short scale, ordinals, currency, dates, reverse parsing, digit conversion. Nothing deferred.

## What

New `openodia.numbers` submodule (accessed as `openodia.numbers.X`):

| Function | Purpose |
|---|---|
| `to_words(n, scale='indian' \| 'short')` | Integer → Odia words |
| `from_words(s, scale=...)` | Odia words → integer |
| `to_ordinal(n)` | 1st-10th irregular, 11+ uses `ତମ` suffix |
| `to_words_currency(amount, currency='INR')` | Rupee/paisa verbalisation with half-up rounding to 2 decimals |
| `to_words_date(date)` | `<day_ordinal> <month>, <year_words>` |
| `ascii_to_odia(s)` / `odia_to_ascii(s)` | Digit translation |

Internal layout:

```
openodia/numbers/
  __init__.py        # public exports
  _tables.py         # single source of truth for 0..99, multipliers, months, ordinals
  _words.py          # to_words / from_words
  _ordinals.py
  _currency.py
  _dates.py
  _digits.py
```

## Tests & coverage

```
tests/test_numbers.py ............... [100%]
80 passed in 0.26s

Name                            Stmts   Miss  Cover
----------------------------------------------------
openodia/numbers/__init__.py        6      0   100%
openodia/numbers/_currency.py      21      0   100%
openodia/numbers/_dates.py         12      0   100%
openodia/numbers/_digits.py         9      0   100%
openodia/numbers/_ordinals.py       9      0   100%
openodia/numbers/_tables.py        10      0   100%
openodia/numbers/_words.py         60      0   100%
----------------------------------------------------
TOTAL                             127      0   100%
```

Full suite: **331 passed** (251 baseline + 80 new). No regressions.

## Edge cases covered

- `to_words`: 0, all under-hundred boundaries, 100, 234, 1234, lakh (12,34,567), crore (1,00,00,000), two-crore-three-lakh (2,03,00,000), negative numbers, all three short-scale tiers (million / billion / trillion), short-scale composition (1,234,567), unknown-scale raise, zero in both scales.
- `from_words`: round-trip across Indian and short for several magnitudes; **intra-group "ଶହ" vs inter-group "ହଜାର+" parser** so `"ଦୁଇ ଶହ ଚଉତିରିଶ ହଜାର"` correctly becomes 234,000 (not 200 + 34,000); extra whitespace tolerated; unrecognised tokens, empty input, `ଋଣାତ୍ମକ` alone, and invalid scale all raise; bare multiplier (`"ଶହ"` alone) resolves to 100.
- `to_ordinal`: all 10 irregular forms; suffix-based 11+; suffix on multi-word forms (`"ଏକ ଶହତମ"`); zero and negative raise.
- `to_words_currency`: integer rupees, with paisa, paisa-only, zero, half-up rounding (`1.005 → 1.01`), `Decimal` input, negative raises, unsupported currency raises.
- `to_words_date`: standard date, irregular day ordinal (`1st`), all 12 months covered, year-zero guard verified via a stub object.
- Digit conversion: parametrised round-trips, non-digits pass through both directions, mixed input behaves as a partial transcoding (`"୧2" → "୧୨"` when going to Odia; `"1୨" → "12"` when going to ASCII).
- Table sanity: `UNDER_HUNDRED` has exactly 100 entries and they're all unique (guards against accidental edits breaking `from_words` round-trip).

## Worth a native-speaker pass

The 0..99 word table at `openodia/numbers/_tables.py:UNDER_HUNDRED` is the linguistic part of this PR. It's the standard literary Odia counting; a native-speaker re-read would be welcome. Any correction lands in that one tuple and is automatically picked up by **all** APIs in this module (and by the round-trip test, since `from_words` reads the same table). I deliberately kept the engineering (composition, place-value, rounding, ordinal suffixing, currency math, date assembly) separate from the word data for exactly this reason.

## Docs

`docs/index.md` updated with a "Numbers and words" section showing every public function plus the note about where the 0..99 table lives.

## Backward compatibility

Pure addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)