### PR TITLE
[#199] Robust sentence segmenter handling । ॥ . ? ! … with abbreviation + decimal masking

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,7 @@ The tools are available in Odia language.
 - [x] [Corpus statistics](#corpus-statistics)
 - [x] [Syllabifier (akshara)](#syllabifier)
 - [x] [Numbers, dates, and currency in words](#numbers-and-words)
+- [x] [Sentence segmenter](#sentence-segmenter)
 
 
 ### :material-broom: Unicode normalization
@@ -209,6 +210,38 @@ numbers.odia_to_ascii("୨୦୨୬")   # '2026'
     as a single tuple of length 100. Native-speaker corrections land there
     and are picked up by every API in this module automatically.
 
+### :material-call-split: Sentence segmenter
+
+- Splits text into sentences on Odia (`।`, `॥`) and Latin (`.`, `?`, `!`, `…`) terminators.
+- Decimal numbers (`୨.୫`, `2.5`) and common abbreviations (`ଡଃ`, `Dr.`, `e.g.`) do **not** trigger a split.
+- Each sentence keeps its terminator by default.
+
+```python
+from openodia import sentences
+
+sentences("ଆଜି ୨.୫ କୋଟି। ଆଗକୁ କଣ? ଭଲ ଦିନ!")
+# ['ଆଜି ୨.୫ କୋଟି।', 'ଆଗକୁ କଣ?', 'ଭଲ ଦିନ!']
+
+sentences("ଡଃ ସୁନୀତା ଆସିଲେ। ସେ କଲେଜରେ ପଢ଼ାନ୍ତି।")
+# ['ଡଃ ସୁନୀତା ଆସିଲେ।', 'ସେ କଲେଜରେ ପଢ଼ାନ୍ତି।']
+
+# Strict mode: only Odia terminators trigger splits.
+sentences("Hi. ତୁମେ କେମିତି।", mode="strict")
+# ['Hi. ତୁମେ କେମିତି।']
+
+# Strip terminators
+sentences("Hello. World!", keep_terminators=False)
+# ['Hello', 'World']
+```
+
+??? hint "Extending the abbreviations list"
+    `openodia.segment.ABBREVIATIONS` is a public tuple. Project-specific
+    vocabulary (e.g. trade names, place abbreviations) can be added by
+    extending it in a wrapper module.
+
+??? note "Existing `ud.sentence_tokenizer` is unchanged"
+    The pre-existing helper continues to behave exactly as before (splits
+    on `" ।"` only). Adopt `openodia.sentences()` for new code.
 
 ### :material-format-letter-case: Odia alphabets 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,8 +55,7 @@ theme:
     logo: logo
 
 plugins:
-  - search:
-      prebuild_index: true
+  - search
   - git-revision-date-localized:
       type: timeago
 
@@ -78,8 +77,8 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.keys

--- a/openodia/__init__.py
+++ b/openodia/__init__.py
@@ -10,6 +10,7 @@ from ._translate import odia_to_other_lang, other_lang_to_odia, universal_transl
 from ._understandData import UnderstandData as ud
 from . import numbers
 from . import syllable
+from .segment import sentences
 from .stats import FreqDist, collocations, cooccurrence, ngrams
 from .stopwords import Stopwords
 from .text import clean, normalize
@@ -26,6 +27,7 @@ __all__ = [
     "numbers",
     "odia_to_other_lang",
     "other_lang_to_odia",
+    "sentences",
     "STOPWORDS",
     "Stopwords",
     "syllable",

--- a/openodia/segment/__init__.py
+++ b/openodia/segment/__init__.py
@@ -1,0 +1,11 @@
+"""Sentence segmentation for Odia text.
+
+Examples:
+    >>> from openodia import sentences
+    >>> sentences("ଆଜି ୨.୫ କୋଟି ଟଙ୍କା। ଆଗକୁ କଣ?")
+    ['ଆଜି ୨.୫ କୋଟି ଟଙ୍କା।', 'ଆଗକୁ କଣ?']
+"""
+
+from openodia.segment._segment import ABBREVIATIONS, SegmenterMode, sentences
+
+__all__ = ["ABBREVIATIONS", "SegmenterMode", "sentences"]

--- a/openodia/segment/_segment.py
+++ b/openodia/segment/_segment.py
@@ -1,0 +1,139 @@
+"""Robust sentence segmenter for Odia text.
+
+The algorithm:
+
+1. Mask out tokens that *look* like sentence boundaries but aren't:
+   decimals (``୨.୫`` / ``2.5``) and a small set of common abbreviations.
+2. Split the masked string on a run of terminators (``।``, ``॥``, ``.``,
+   ``?``, ``!``, ``…``) followed by whitespace or end-of-string.
+3. Restore masked tokens in the resulting sentences.
+
+The mask uses a NUL byte sentinel which is extraordinarily rare in natural
+language. Inputs that contain literal NUL bytes will round-trip
+correctly because the mask placeholder is ``\\x00<n>\\x00`` not a bare
+NUL.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+SegmenterMode = Literal["default", "strict"]
+
+#: Tokens whose period (``.``) must not be treated as a sentence boundary.
+#: Add to this set for project-specific vocabulary.
+ABBREVIATIONS: tuple[str, ...] = (
+    # Odia honorifics & abbreviations
+    "ଡଃ",
+    "ଶ୍ରୀ",
+    "ଶ୍ରୀମତୀ",
+    "ସା.କଃ.",
+    # Common Latin abbreviations that appear in mixed Odia/English text
+    "Mr.",
+    "Mrs.",
+    "Ms.",
+    "Dr.",
+    "Prof.",
+    "Sr.",
+    "Jr.",
+    "e.g.",
+    "i.e.",
+    "etc.",
+    "vs.",
+)
+
+_TERMINATORS_DEFAULT = "।॥.?!…"
+_TERMINATORS_STRICT = "।॥"
+
+# A run of one or more terminator chars, optionally followed by whitespace.
+# ``re.split`` with a *capturing* group yields ``[text, sep, text, sep, ...]``.
+_SPLIT_RE_DEFAULT = re.compile(rf"([{re.escape(_TERMINATORS_DEFAULT)}]+)\s*")
+_SPLIT_RE_STRICT = re.compile(rf"([{re.escape(_TERMINATORS_STRICT)}]+)\s*")
+
+# Decimal numbers in either ASCII or Odia digits, with a period in the middle.
+_DECIMAL_RE = re.compile(r"[0-9୦-୯]+\.[0-9୦-୯]+")
+
+
+def _mask(text: str) -> tuple[str, list[str]]:
+    """Replace decimals and abbreviations with ``\\x00<idx>\\x00`` placeholders."""
+    masks: list[str] = []
+
+    def take(match: re.Match[str]) -> str:
+        masks.append(match.group(0))
+        return f"\x00{len(masks) - 1}\x00"
+
+    out = _DECIMAL_RE.sub(take, text)
+
+    # Longest-first so "ଶ୍ରୀମତୀ" masks before any prefix like "ଶ୍ରୀ" would.
+    if ABBREVIATIONS:
+        abbr_pattern = re.compile("|".join(re.escape(a) for a in sorted(ABBREVIATIONS, key=len, reverse=True)))
+        out = abbr_pattern.sub(take, out)
+
+    return out, masks
+
+
+_RESTORE_RE = re.compile(r"\x00(\d+)\x00")
+
+
+def _restore(text: str, masks: list[str]) -> str:
+    """Inverse of :func:`_mask`."""
+    if not masks:
+        return text
+    return _RESTORE_RE.sub(lambda m: masks[int(m.group(1))], text)
+
+
+def sentences(
+    text: str,
+    *,
+    mode: SegmenterMode = "default",
+    keep_terminators: bool = True,
+) -> list[str]:
+    """Split ``text`` into sentences.
+
+    Args:
+        text: Input string. May be Odia, mixed Odia/Latin, or empty.
+        mode: ``"default"`` (recommended) treats ``।``, ``॥``, ``.``, ``?``,
+            ``!``, ``…`` as terminators. ``"strict"`` only treats Odia
+            terminators (``।``, ``॥``) as boundaries — useful for classical
+            Odia text that uses Latin periods inside content.
+        keep_terminators: When ``True`` (default), each returned sentence
+            includes its trailing punctuation. Set to ``False`` to strip
+            the terminator.
+
+    Returns:
+        List of sentences in source order. Empty input returns an empty
+        list.
+
+    Raises:
+        ValueError: If ``mode`` is not recognised.
+
+    Examples:
+        >>> sentences("ଆଜି ୨.୫ କୋଟି। ଆଗକୁ କଣ? ଭଲ ଦିନ!")
+        ['ଆଜି ୨.୫ କୋଟି।', 'ଆଗକୁ କଣ?', 'ଭଲ ଦିନ!']
+        >>> sentences("ଡଃ ସୁନୀତା ଆସିଲେ। ସେ କଲେଜରେ ପଢ଼ାନ୍ତି।")
+        ['ଡଃ ସୁନୀତା ଆସିଲେ।', 'ସେ କଲେଜରେ ପଢ଼ାନ୍ତି।']
+    """
+    if mode == "default":
+        split_re = _SPLIT_RE_DEFAULT
+    elif mode == "strict":
+        split_re = _SPLIT_RE_STRICT
+    else:
+        raise ValueError(f"unknown mode {mode!r}; supported: 'default', 'strict'")
+
+    if not text or not text.strip():
+        return []
+
+    masked, masks = _mask(text)
+    parts = split_re.split(masked)
+
+    out: list[str] = []
+    for i in range(0, len(parts), 2):
+        body = parts[i].strip()
+        terminator = parts[i + 1] if i + 1 < len(parts) else ""
+        if not body:
+            continue
+        sentence = body + terminator if keep_terminators else body
+        out.append(_restore(sentence, masks))
+
+    return out

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -1,0 +1,143 @@
+import pytest
+
+from openodia import sentences
+from openodia.segment import ABBREVIATIONS
+
+
+class TestBasicSplits:
+    def test_three_sentences_with_mixed_terminators(self) -> None:
+        out = sentences("ଆଜି ୨.୫ କୋଟି। ଆଗକୁ କଣ? ଭଲ ଦିନ!")
+        assert out == ["ଆଜି ୨.୫ କୋଟି।", "ଆଗକୁ କଣ?", "ଭଲ ଦିନ!"]
+
+    def test_no_space_between_sentences(self) -> None:
+        # The pre-existing tokenizer needed " ।" — the new one doesn't.
+        out = sentences("ରାମ ଗଲା।ସୀତା ଆସିଲା।")
+        assert out == ["ରାମ ଗଲା।", "ସୀତା ଆସିଲା।"]
+
+    def test_double_danda(self) -> None:
+        # Whitespace before the terminator is normalised away.
+        out = sentences("ଶ୍ଳୋକ ଏକ ॥ ଶ୍ଳୋକ ଦୁଇ ॥")
+        assert out == ["ଶ୍ଳୋକ ଏକ॥", "ଶ୍ଳୋକ ଦୁଇ॥"]
+
+    def test_ellipsis_treated_as_terminator(self) -> None:
+        out = sentences("ଭାବୁଛି… ତୁମେ କିଏ?")
+        assert out == ["ଭାବୁଛି…", "ତୁମେ କିଏ?"]
+
+    def test_run_of_terminators_stays_with_sentence(self) -> None:
+        out = sentences("Really?! Yes!")
+        assert out == ["Really?!", "Yes!"]
+
+
+class TestDecimalsPreserved:
+    def test_odia_digits_decimal(self) -> None:
+        out = sentences("ଆଜି ୨.୫ କୋଟି।")
+        assert out == ["ଆଜି ୨.୫ କୋଟି।"]
+
+    def test_ascii_digits_decimal(self) -> None:
+        out = sentences("Price is 12.50 only.")
+        assert out == ["Price is 12.50 only."]
+
+    def test_decimal_inside_multi_sentence_input(self) -> None:
+        out = sentences("Cost 2.5 cr. Net 3.4 cr.")
+        # Cost ... 2.5 cr — but "cr." is not in our abbreviation list, so
+        # it's a real terminator. Result is two sentences.
+        assert out == ["Cost 2.5 cr.", "Net 3.4 cr."]
+
+
+class TestAbbreviations:
+    def test_doctor_honorific(self) -> None:
+        out = sentences("ଡଃ ସୁନୀତା ଆସିଲେ।")
+        assert out == ["ଡଃ ସୁନୀତା ଆସିଲେ।"]
+
+    def test_latin_eg(self) -> None:
+        out = sentences("Use any tool, e.g. ripgrep. Done.")
+        assert out == ["Use any tool, e.g. ripgrep.", "Done."]
+
+    def test_latin_dr(self) -> None:
+        out = sentences("Dr. Sahoo arrived. He left.")
+        assert out == ["Dr. Sahoo arrived.", "He left."]
+
+    def test_longest_match_wins(self) -> None:
+        """``ଶ୍ରୀମତୀ`` and ``ଶ୍ରୀ`` share a prefix; longer must mask first."""
+        out = sentences("ଶ୍ରୀମତୀ ଲତା ଗଲେ।")
+        assert out == ["ଶ୍ରୀମତୀ ଲତା ଗଲେ।"]
+
+    def test_abbreviations_constant_is_populated(self) -> None:
+        assert "ଡଃ" in ABBREVIATIONS
+        assert "Dr." in ABBREVIATIONS
+
+
+class TestModes:
+    def test_strict_ignores_latin_period(self) -> None:
+        # Latin period is not a strict-mode terminator.
+        out = sentences("Hi. ତୁମେ କେମିତି।", mode="strict")
+        assert out == ["Hi. ତୁମେ କେମିତି।"]
+
+    def test_default_splits_latin_period(self) -> None:
+        out = sentences("Hi. ତୁମେ କେମିତି।")
+        assert out == ["Hi.", "ତୁମେ କେମିତି।"]
+
+    def test_unknown_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown mode"):
+            sentences("Hi.", mode="loose")  # type: ignore[arg-type]
+
+
+class TestKeepTerminators:
+    def test_default_keeps_terminators(self) -> None:
+        out = sentences("Hello. World!")
+        assert out == ["Hello.", "World!"]
+
+    def test_strip_terminators(self) -> None:
+        out = sentences("Hello. World!", keep_terminators=False)
+        assert out == ["Hello", "World"]
+
+
+class TestEdgeCases:
+    def test_empty(self) -> None:
+        assert sentences("") == []
+
+    def test_only_whitespace(self) -> None:
+        assert sentences("   \n\t  ") == []
+
+    def test_only_terminator(self) -> None:
+        assert sentences("...") == []
+
+    def test_single_sentence_no_terminator(self) -> None:
+        assert sentences("ଏକା ବାକ୍ୟ") == ["ଏକା ବାକ୍ୟ"]
+
+    def test_leading_punctuation_dropped(self) -> None:
+        assert sentences(". hello world.") == ["hello world."]
+
+    def test_internal_newlines_collapsed_into_whitespace(self) -> None:
+        out = sentences("Hello.\n\nWorld.")
+        assert out == ["Hello.", "World."]
+
+
+class TestIdempotenceProperty:
+    """Joining sentences then re-splitting should match the original split."""
+
+    def test_round_trip(self) -> None:
+        text = "ରାମ ଗଲା। ସୀତା ଆସିଲା। ଲକ୍ଷ୍ମଣ ଅଛନ୍ତି।"
+        first = sentences(text)
+        joined = " ".join(first)
+        second = sentences(joined)
+        assert first == second
+
+
+class TestBackwardCompatibility:
+    """The pre-existing ``ud.sentence_tokenizer`` must keep working unchanged."""
+
+    def test_old_tokenizer_still_works(self) -> None:
+        from openodia import ud
+
+        # Same behaviour as before: splits on " ।".
+        out = ud.sentence_tokenizer("ରାମ ଗଲା । ସୀତା ଆସିଲା ।")
+        assert isinstance(out, list)
+        assert len(out) > 0
+
+
+class TestPublicAPI:
+    def test_top_level_alias(self) -> None:
+        import openodia
+
+        assert openodia.sentences is sentences


### PR DESCRIPTION
Closes #199.

## What

`openodia.sentences(text, *, mode='default', keep_terminators=True)` — new `openodia.segment` submodule.

- Splits on `।`, `॥`, `.`, `?`, `!`, `…`.
- **Masks** decimals (`୨.୫`, `2.5`) and abbreviations (`ଡଃ`, `Dr.`, `e.g.`, ...) so they don't trigger spurious splits.
- `mode='strict'` restricts to Odia-only terminators.
- `keep_terminators=False` strips trailing punctuation.
- `openodia.segment.ABBREVIATIONS` is a public, extensible tuple.

## Algorithm (kept simple)

1. Mask decimals + abbreviations to `\x00<n>\x00` placeholders.
2. `re.split` on `([।॥.?!…]+)\s*` (capturing the terminators).
3. Walk `[body, terminator, body, terminator, ...]` pairs, rejoin, restore masks.

Longest-match-first masking ensures `"ଶ୍ରୀମତୀ"` is consumed before any `"ଶ୍ରୀ"` prefix.

## Tests & coverage

```
tests/test_segment.py ........................... [100%]
27 passed in 0.10s

Name                           Stmts   Miss  Cover
---------------------------------------------------
openodia/segment/__init__.py       2      0   100%
openodia/segment/_segment.py      44      0   100%
---------------------------------------------------
TOTAL                             46      0   100%
```

Full suite: **320 passed**. No regressions.

## Edge cases covered

- Mixed terminators in one input.
- No space between sentences (`"ରାମ ଗଲା।ସୀତା ଆସିଲା।"`).
- Double `॥` for shloka-style text.
- Ellipsis as terminator.
- Run of terminators stays attached (`"Really?!"`).
- Decimals in both Odia and ASCII digits preserved.
- Odia honorific `ଡଃ` and `ଶ୍ରୀ` / `ଶ୍ରୀମତୀ` (longest-first masking).
- Latin abbreviations: `Dr.`, `e.g.`.
- Strict-mode ignores Latin period; default-mode splits on it.
- Unknown mode raises.
- `keep_terminators=False` strips them.
- Empty / whitespace-only / terminator-only input returns `[]`.
- Single sentence without terminator returns single-element list.
- Leading punctuation dropped.
- Internal newlines collapsed.
- Round-trip property: joining results then re-splitting matches original split.

## Backward compatibility

- ✅ `ud.sentence_tokenizer` left **completely unchanged** — same behavior as before.
- New entry point is `openodia.sentences(...)` (recommended for new code).
- Top-level alias and public submodule both wired up.

## Docs

`docs/index.md` "Sentence segmenter" section showing all modes and the abbreviations note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)