### PR TITLE
[#203] Syllabifier (akshara segmentation)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ The tools are available in Odia language.
 - [x] [Add Dictionary corpus](#offline-dictionary)
 - [x] [Unicode normalization & clean](#unicode-normalization)
 - [x] [Corpus statistics](#corpus-statistics)
+- [x] [Syllabifier (akshara)](#syllabifier)
 
 
 ### :material-broom: Unicode normalization
@@ -135,6 +136,29 @@ cooccurrence(tokens, window=2)
 ??? note "v1 scope"
     - `collocations` ships PMI scoring only. Log-likelihood and chi-square are easy follow-ups.
     - Plot helpers are intentionally out of scope to keep the base install free of matplotlib.
+
+### :material-format-text-variant: Syllabifier
+
+- Splits a word into **aksharas** (orthographic syllables) using the Odia Unicode block rules: independent vowels, consonant clusters joined by halant (`୍`), matras, modifiers, and nukta.
+- Useful for TTS frontends, hyphenation/typography, character-level ML, and readability scoring.
+
+```python
+from openodia import syllable
+
+syllable.split("ନମସ୍କାର")        # ['ନ', 'ମ', 'ସ୍କା', 'ର']
+syllable.split("ଓଡ଼ିଆ")            # ['ଓ', 'ଡ଼ି', 'ଆ']
+syllable.split("ବିଦ୍ୟାଳୟ")        # ['ବି', 'ଦ୍ୟା', 'ଳ', 'ୟ']
+
+syllable.count("ବିଦ୍ୟାଳୟ")        # 4
+
+syllable.hyphenate("ବିଦ୍ୟାଳୟ")    # 'ବି-ଦ୍ୟା-ଳ-ୟ'
+syllable.hyphenate("ନମସ୍କାର ଓଡ଼ିଆ", separator="·")
+# 'ନ·ମ·ସ୍କା·ର ଓ·ଡ଼ି·ଆ'
+```
+
+??? note "Round-trip property"
+    `"".join(syllable.split(word)) == word` for any input — the splitter
+    is a strict tokeniser, never modifying or normalising characters.
 
 ### :material-format-letter-case: Odia alphabets 
 

--- a/openodia/__init__.py
+++ b/openodia/__init__.py
@@ -8,6 +8,7 @@ from ._odianames import Names as name
 from ._summarization import WordFrequency
 from ._translate import odia_to_other_lang, other_lang_to_odia, universal_translation
 from ._understandData import UnderstandData as ud
+from . import syllable
 from .stats import FreqDist, collocations, cooccurrence, ngrams
 from .stopwords import Stopwords
 from .text import clean, normalize
@@ -25,6 +26,7 @@ __all__ = [
     "other_lang_to_odia",
     "STOPWORDS",
     "Stopwords",
+    "syllable",
     "ud",
     "universal_translation",
     "WordFrequency",

--- a/openodia/syllable/__init__.py
+++ b/openodia/syllable/__init__.py
@@ -1,0 +1,15 @@
+"""Akshara (orthographic syllable) segmentation for Odia text.
+
+Examples:
+    >>> from openodia import syllable
+    >>> syllable.split("ନମସ୍କାର")
+    ['ନ', 'ମ', 'ସ୍କା', 'ର']
+    >>> syllable.count("ବିଦ୍ୟାଳୟ")
+    4
+    >>> syllable.hyphenate("ବିଦ୍ୟାଳୟ")
+    'ବି-ଦ୍ୟା-ଳ-ୟ'
+"""
+
+from openodia.syllable._syllable import count, hyphenate, split
+
+__all__ = ["count", "hyphenate", "split"]

--- a/openodia/syllable/_syllable.py
+++ b/openodia/syllable/_syllable.py
@@ -1,0 +1,173 @@
+"""Akshara segmentation state machine.
+
+An *akshara* is the Odia orthographic syllable: one or more consonants
+joined by halant (``୍``), optionally followed by a vowel sign and final
+modifiers. The independent vowels (``ଅ``, ``ଆ``, …) form their own
+aksharas.
+
+The categoriser below covers the Odia Unicode block (U+0B00–U+0B7F).
+Anything outside that block (Latin letters, digits, punctuation,
+whitespace) is emitted as its own unit so callers can decide what to do
+with it.
+"""
+
+from __future__ import annotations
+
+# ----- Codepoint categories ------------------------------------------------
+
+_INDEPENDENT_VOWELS: frozenset[str] = frozenset(
+    "ଅଆଇଈଉଊଋଌଏଐଓଔ"  # U+0B05..U+0B14
+    "ୠୡ"  # U+0B60..U+0B61 (vocalic R̄ / L̄)
+)
+
+_CONSONANTS: frozenset[str] = frozenset(
+    "କଖଗଘଙ"  # gutturals
+    "ଚଛଜଝଞ"  # palatals
+    "ଟଠଡଢଣ"  # retroflex
+    "ତଥଦଧନ"  # dentals
+    "ପଫବଭମ"  # labials
+    "ଯରଲଳଵଶଷସହ"  # semivowels + sibilants + ha
+) | frozenset(
+    # Pre-composed nukta consonants. Spelled via chr() so the source file
+    # cannot silently decompose them via the editor's NFC normalization
+    # and leak a stray U+0B3C nukta into the consonant set.
+    [
+        chr(0x0B5C),  # ଡ଼
+        chr(0x0B5D),  # ଢ଼
+        chr(0x0B5F),  # ୟ
+    ]
+)
+
+_MATRAS: frozenset[str] = frozenset(
+    "ାିୀୁୂୃୄେୈୋୌୖୗୢୣ"  # vowel signs (dependent vowels)
+)
+
+_HALANT: str = "୍"  # U+0B4D, the virama
+_NUKTA: str = "଼"  # U+0B3C
+_MODIFIERS: frozenset[str] = frozenset("ଁଂଃ")  # chandrabindu, anusvara, visarga
+
+
+def _is_continuation(ch: str) -> bool:
+    """Characters that always attach to the running akshara."""
+    return ch in _MATRAS or ch in _MODIFIERS or ch == _NUKTA
+
+
+# ----- Public API ---------------------------------------------------------
+
+
+def split(word: str) -> list[str]:
+    """Split a word into aksharas.
+
+    Args:
+        word: A single Odia word. Whitespace and non-Odia characters are
+            emitted as their own units (one entry per character / run of
+            whitespace).
+
+    Returns:
+        A list of aksharas in source order. Empty input returns ``[]``.
+
+    Examples:
+        >>> split("ନମସ୍କାର")
+        ['ନ', 'ମ', 'ସ୍କା', 'ର']
+        >>> split("ଓଡ଼ିଆ")
+        ['ଓ', 'ଡ଼ି', 'ଆ']
+    """
+    if not word:
+        return []
+
+    aksharas: list[str] = []
+    current: list[str] = []
+    expecting_consonant = False  # set after a halant
+
+    def flush() -> None:
+        if current:
+            aksharas.append("".join(current))
+            current.clear()
+
+    for ch in word:
+        if ch in _CONSONANTS:
+            if expecting_consonant or not current:
+                current.append(ch)
+            else:
+                flush()
+                current.append(ch)
+            expecting_consonant = False
+
+        elif ch in _INDEPENDENT_VOWELS:
+            flush()
+            current.append(ch)
+            expecting_consonant = False
+
+        elif ch == _HALANT:
+            current.append(ch)
+            expecting_consonant = True
+
+        elif _is_continuation(ch):
+            current.append(ch)
+            expecting_consonant = False
+
+        else:
+            # Out-of-block character (digit, punctuation, whitespace, Latin
+            # letter). Emit it as its own unit.
+            flush()
+            aksharas.append(ch)
+            expecting_consonant = False
+
+    flush()
+    return aksharas
+
+
+def count(word: str) -> int:
+    """Number of Odia aksharas in ``word``.
+
+    Non-Odia characters (whitespace, punctuation, digits, Latin letters)
+    are *not* counted.
+    """
+    return sum(1 for unit in split(word) if any(ch in _INDEPENDENT_VOWELS or ch in _CONSONANTS for ch in unit))
+
+
+def hyphenate(word: str, separator: str = "-") -> str:
+    """Join aksharas with ``separator``.
+
+    Whitespace runs in the input become natural breaks: each word is
+    hyphenated independently and the original whitespace is preserved
+    between them.
+
+    Args:
+        word: Odia text (one or more words).
+        separator: String inserted between consecutive aksharas of the
+            same word. Defaults to ``"-"``.
+
+    Returns:
+        The hyphenated string.
+
+    Examples:
+        >>> hyphenate("ବିଦ୍ୟାଳୟ")
+        'ବି-ଦ୍ୟା-ଳ-ୟ'
+        >>> hyphenate("ନମସ୍କାର ଓଡ଼ିଆ")
+        'ନ-ମ-ସ୍କା-ର ଓ-ଡ଼ି-ଆ'
+    """
+    if not word:
+        return ""
+
+    out: list[str] = []
+    buffer: list[str] = []  # aksharas for the current word
+
+    def flush_word() -> None:
+        if buffer:
+            out.append(separator.join(buffer))
+            buffer.clear()
+
+    for token in split(word):
+        if token.isspace() or (len(token) == 1 and not _is_odia(token)):
+            flush_word()
+            out.append(token)
+        else:
+            buffer.append(token)
+
+    flush_word()
+    return "".join(out)
+
+
+def _is_odia(ch: str) -> bool:
+    return ch in _INDEPENDENT_VOWELS or ch in _CONSONANTS or ch in _MATRAS or ch in _MODIFIERS or ch == _HALANT or ch == _NUKTA

--- a/tests/test_syllable.py
+++ b/tests/test_syllable.py
@@ -1,0 +1,120 @@
+import pytest
+
+from openodia import syllable
+
+
+class TestSplit:
+    @pytest.mark.parametrize(
+        "word, expected",
+        [
+            ("ନମସ୍କାର", ["ନ", "ମ", "ସ୍କା", "ର"]),
+            ("ଓଡ଼ିଆ", ["ଓ", "ଡ଼ି", "ଆ"]),
+            ("ବିଦ୍ୟାଳୟ", ["ବି", "ଦ୍ୟା", "ଳ", "ୟ"]),
+            ("ରାମ", ["ରା", "ମ"]),
+            ("ସୀତା", ["ସୀ", "ତା"]),
+        ],
+    )
+    def test_basic_words(self, word: str, expected: list[str]) -> None:
+        assert syllable.split(word) == expected
+
+    def test_independent_vowel_only(self) -> None:
+        assert syllable.split("ଆ") == ["ଆ"]
+
+    def test_consonant_only(self) -> None:
+        # Bare consonant with implicit schwa.
+        assert syllable.split("କ") == ["କ"]
+
+    def test_conjunct_cluster(self) -> None:
+        # ସ + ୍ + କ + ୍ + ର = ସ୍କ୍ର
+        assert syllable.split("ସ୍କ୍ର") == ["ସ୍କ୍ର"]
+
+    def test_modifiers_cling_to_akshara(self) -> None:
+        # ଅଁ should be a single akshara.
+        assert syllable.split("ଅଁ") == ["ଅଁ"]
+
+    def test_anusvara_after_consonant(self) -> None:
+        assert syllable.split("ରଂ") == ["ରଂ"]
+
+    def test_visarga_after_consonant(self) -> None:
+        assert syllable.split("ରଃ") == ["ରଃ"]
+
+    def test_nukta_attaches(self) -> None:
+        # ଡ + ଼ + ି should produce one akshara: ଡ଼ି
+        assert syllable.split("ଡ଼ି") == ["ଡ଼ି"]
+
+    def test_independent_vowel_breaks_akshara(self) -> None:
+        # "କଆ" should be two aksharas: ['କ', 'ଆ']
+        assert syllable.split("କଆ") == ["କ", "ଆ"]
+
+    def test_empty_string(self) -> None:
+        assert syllable.split("") == []
+
+    def test_non_odia_chars_emitted_individually(self) -> None:
+        assert syllable.split("ର ର") == ["ର", " ", "ର"]
+        assert syllable.split("ର!") == ["ର", "!"]
+
+    def test_digits_emitted_individually(self) -> None:
+        # Odia digits are not aksharas — they are emitted as own units.
+        assert syllable.split("୨୩") == ["୨", "୩"]
+
+
+class TestCount:
+    @pytest.mark.parametrize(
+        "word, expected",
+        [
+            ("ନମସ୍କାର", 4),
+            ("ଓଡ଼ିଆ", 3),
+            ("ବିଦ୍ୟାଳୟ", 4),
+            ("ରାମ", 2),
+            ("", 0),
+        ],
+    )
+    def test_count_matches_split_excluding_non_odia(self, word: str, expected: int) -> None:
+        assert syllable.count(word) == expected
+
+    def test_count_ignores_whitespace_and_punctuation(self) -> None:
+        # 2 aksharas + space + ! → still 2.
+        assert syllable.count("ର ର!") == 2
+
+    def test_count_ignores_digits(self) -> None:
+        assert syllable.count("ର୨") == 1
+
+
+class TestHyphenate:
+    def test_basic(self) -> None:
+        assert syllable.hyphenate("ବିଦ୍ୟାଳୟ") == "ବି-ଦ୍ୟା-ଳ-ୟ"
+
+    def test_custom_separator(self) -> None:
+        assert syllable.hyphenate("ବିଦ୍ୟାଳୟ", separator="·") == "ବି·ଦ୍ୟା·ଳ·ୟ"
+
+    def test_preserves_inter_word_whitespace(self) -> None:
+        assert syllable.hyphenate("ନମସ୍କାର ଓଡ଼ିଆ") == "ନ-ମ-ସ୍କା-ର ଓ-ଡ଼ି-ଆ"
+
+    def test_single_akshara_word(self) -> None:
+        assert syllable.hyphenate("ଆ") == "ଆ"
+
+    def test_empty_string(self) -> None:
+        assert syllable.hyphenate("") == ""
+
+    def test_punctuation_breaks_hyphenation(self) -> None:
+        # "ର!" → 'ର' + '!' — they shouldn't be joined with a hyphen.
+        assert syllable.hyphenate("ର!") == "ର!"
+
+
+class TestIdempotenceProperty:
+    """``"".join(split(w))`` recovers the original word."""
+
+    @pytest.mark.parametrize(
+        "word",
+        ["ନମସ୍କାର", "ଓଡ଼ିଆ", "ବିଦ୍ୟାଳୟ", "ରାମ", "ସୀତା"],
+    )
+    def test_split_then_join(self, word: str) -> None:
+        assert "".join(syllable.split(word)) == word
+
+
+class TestPublicAPI:
+    def test_submodule_accessible(self) -> None:
+        import openodia
+
+        assert openodia.syllable is syllable
+        assert callable(openodia.syllable.split)


### PR DESCRIPTION
Closes #203.

## What

`openodia.syllable` submodule with three functions:

- **`split(word)`** — tokenises into aksharas. Always satisfies `\"\".join(split(w)) == w`.
- **`count(word)`** — number of Odia aksharas; ignores whitespace, punctuation, digits, and Latin letters.
- **`hyphenate(word, separator='-')`** — joins aksharas; preserves inter-word whitespace.

```python
syllable.split(\"ନମସ୍କାର\")     # ['ନ', 'ମ', 'ସ୍କା', 'ର']
syllable.split(\"ଓଡ଼ିଆ\")         # ['ଓ', 'ଡ଼ି', 'ଆ']
syllable.split(\"ବିଦ୍ୟାଳୟ\")     # ['ବି', 'ଦ୍ୟା', 'ଳ', 'ୟ']
syllable.hyphenate(\"ବିଦ୍ୟାଳୟ\") # 'ବି-ଦ୍ୟା-ଳ-ୟ'
```

## Algorithm

State machine over Odia Unicode codepoints:

- **Consonant** starts a new akshara unless preceded by a halant (in which case it extends the current).
- **Independent vowel** always starts a new akshara.
- **Halant** (`୍`) appends to current and signals \"next consonant attaches\".
- **Matra**, **modifier** (`ଁ`, `ଂ`, `ଃ`), **nukta** (`଼`) — always attach.
- Anything outside the Odia block is emitted as its own unit.

## One Unicode footgun caught during testing

The pre-composed nukta consonants `ଡ଼` (U+0B5C), `ଢ଼` (U+0B5D), `ୟ` (U+0B5F) are now built with `chr()` calls. Reason: when written as a literal Python string the editor / file system can silently decompose `ଡ଼` into `ଡ + ଼` — which would leak the nukta U+0B3C into the consonant set, breaking every word containing nukta. Building the set via `chr(0x0B5C)` etc. is immune.

The decomposed form (`ଡ + ଼`) is still handled correctly by the consonant + continuation logic, so both encodings produce identical output.

## Tests & coverage

```
tests/test_syllable.py ................................... [100%]
35 passed in 0.29s

Name                             Stmts   Miss  Cover
-----------------------------------------------------
openodia/syllable/__init__.py        2      0   100%
openodia/syllable/_syllable.py      61      0   100%
-----------------------------------------------------
TOTAL                               63      0   100%
```

Full suite: **328 passed**. No regressions.

## Edge cases covered

- 5 reference words (ନମସ୍କାର, ଓଡ଼ିଆ, ବିଦ୍ୟାଳୟ, ରାମ, ସୀତା).
- Independent-vowel-only, consonant-only, conjunct cluster `ସ୍କ୍ର`.
- Modifiers cling: `ଅଁ`, `ରଂ`, `ରଃ`.
- Nukta attaches (both pre-composed `U+0B5C` and decomposed `ଡ + ଼` forms).
- Independent vowel breaks the running akshara (`କଆ` → 2 entries).
- Empty, whitespace, punctuation, digits — emitted individually.
- `count` ignores whitespace / punctuation / digits.
- `hyphenate` preserves inter-word whitespace; custom separator; empty input; punctuation breaks hyphenation.
- Round-trip property tested on all 5 reference words: `\"\".join(split(w)) == w`.

## Backward compatibility

Pure addition. Accessed as `openodia.syllable.X`.

## Docs

`docs/index.md` \"Syllabifier\" section with examples and round-trip note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)