### PR TITLE
[#196] Indic-to-Indic transliteration (Odia ↔ Devanagari/Bengali/Tamil/...)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ The tools are available in Odia language.
 - [x] [Unicode normalization & clean](#unicode-normalization)
 - [x] [Corpus statistics](#corpus-statistics)
 - [x] [Syllabifier (akshara)](#syllabifier)
+- [x] [Indic-to-Indic transliteration](#indic-transliteration)
 
 
 ### :material-broom: Unicode normalization
@@ -159,6 +160,30 @@ syllable.hyphenate("ନମସ୍କାର ଓଡ଼ିଆ", separator="·")
 ??? note "Round-trip property"
     `"".join(syllable.split(word)) == word` for any input — the splitter
     is a strict tokeniser, never modifying or normalising characters.
+
+### :material-translate-variant: Indic transliteration
+
+- Script-only transliteration between Brahmic Indic scripts: **Devanagari**, **Bengali / Assamese**, **Gurmukhi**, **Gujarati**, **Odia**, **Tamil**, **Telugu**, **Kannada**, **Malayalam**.
+- Deterministic, fast, no external dependencies — pure Unicode block-offset translation.
+- Useful for cross-script reading, ML corpus alignment, and name normalisation across regions.
+
+```python
+from openodia import indic
+
+indic.transliterate("ଓଡ଼ିଆ", from_script="odia", to_script="devanagari")
+# 'ओड़िआ'
+
+indic.transliterate("नमस्ते", from_script="devanagari", to_script="odia")
+# 'ନମସ୍ତେ'
+
+indic.SCRIPTS  # ('devanagari', 'bengali', 'assamese', 'gurmukhi', 'gujarati', 'odia', 'tamil', 'telugu', 'kannada', 'malayalam')
+```
+
+??? note "Tamil caveat"
+    Tamil's encoding has only one consonant per articulation group. Inputs
+    with Devanagari/Odia aspirated or voiced consonants will land on
+    unassigned Tamil codepoints (rendered as placeholder boxes). This is
+    surfaced rather than silently collapsed.
 
 ### :material-format-letter-case: Odia alphabets 
 

--- a/openodia/__init__.py
+++ b/openodia/__init__.py
@@ -8,6 +8,7 @@ from ._odianames import Names as name
 from ._summarization import WordFrequency
 from ._translate import odia_to_other_lang, other_lang_to_odia, universal_translation
 from ._understandData import UnderstandData as ud
+from . import indic
 from . import syllable
 from .stats import FreqDist, collocations, cooccurrence, ngrams
 from .stopwords import Stopwords
@@ -19,6 +20,7 @@ __all__ = [
     "collocations",
     "cooccurrence",
     "FreqDist",
+    "indic",
     "name",
     "ngrams",
     "normalize",

--- a/openodia/indic/__init__.py
+++ b/openodia/indic/__init__.py
@@ -1,0 +1,13 @@
+"""Script-only transliteration between Indic Brahmic scripts.
+
+Examples:
+    >>> from openodia import indic
+    >>> indic.transliterate("ଓଡ଼ିଆ", from_script="odia", to_script="devanagari")
+    'ओड़िआ'
+    >>> indic.transliterate("भारत", from_script="devanagari", to_script="odia")
+    'ଭାରତ'
+"""
+
+from openodia.indic._indic import SCRIPTS, Script, transliterate
+
+__all__ = ["SCRIPTS", "Script", "transliterate"]

--- a/openodia/indic/_indic.py
+++ b/openodia/indic/_indic.py
@@ -1,0 +1,93 @@
+"""Brahmic-block offset transliteration.
+
+The Indic Unicode blocks (Devanagari, Bengali, Gurmukhi, Gujarati, Odia,
+Tamil, Telugu, Kannada, Malayalam) share a parallel layout: characters
+at the same offset within their block represent the same phonetic value.
+Transliterating between two scripts is therefore a single offset
+addition per codepoint that falls inside the source block. Characters
+outside the source block (Latin letters, digits, whitespace,
+punctuation, characters in other Indic blocks) pass through unchanged.
+
+Tamil caveat: Tamil's encoding has only one consonant per articulation
+group (no aspirated / voiced contrasts). Devanagari ``ख`` (U+0916,
+offset 0x16) maps to U+0B96 in the Tamil block — which is unassigned.
+That codepoint still appears in the output and most renderers will show
+a placeholder box; we surface this rather than guessing a collapse.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+Script = Literal[
+    "devanagari",
+    "bengali",
+    "assamese",
+    "gurmukhi",
+    "gujarati",
+    "odia",
+    "tamil",
+    "telugu",
+    "kannada",
+    "malayalam",
+]
+
+#: Block start offset per supported script.
+_SCRIPT_OFFSETS: dict[Script, int] = {
+    "devanagari": 0x0900,
+    "bengali": 0x0980,
+    "assamese": 0x0980,  # Assamese shares the Bengali block.
+    "gurmukhi": 0x0A00,
+    "gujarati": 0x0A80,
+    "odia": 0x0B00,
+    "tamil": 0x0B80,
+    "telugu": 0x0C00,
+    "kannada": 0x0C80,
+    "malayalam": 0x0D00,
+}
+
+_BLOCK_SIZE = 0x80  # Each Indic block spans 128 codepoints.
+
+#: Public list of supported script names.
+SCRIPTS: tuple[Script, ...] = tuple(_SCRIPT_OFFSETS.keys())
+
+
+def transliterate(text: str, from_script: Script, to_script: Script) -> str:
+    """Transliterate ``text`` from one Indic script to another.
+
+    Only the codepoints belonging to ``from_script`` are translated;
+    everything else (whitespace, Latin letters, digits, punctuation,
+    characters in other Indic blocks) is preserved verbatim.
+
+    Args:
+        text: Source string.
+        from_script: Name of the source script.
+        to_script: Name of the destination script.
+
+    Returns:
+        The transliterated string. Same length as ``text``.
+
+    Raises:
+        ValueError: If either script name is unknown.
+    """
+    if from_script not in _SCRIPT_OFFSETS:
+        raise ValueError(f"unknown from_script {from_script!r}; supported: {tuple(_SCRIPT_OFFSETS)}")
+    if to_script not in _SCRIPT_OFFSETS:
+        raise ValueError(f"unknown to_script {to_script!r}; supported: {tuple(_SCRIPT_OFFSETS)}")
+
+    src_offset = _SCRIPT_OFFSETS[from_script]
+    dst_offset = _SCRIPT_OFFSETS[to_script]
+    if src_offset == dst_offset:
+        # No-op: same block (or aliased — e.g. Assamese ↔ Bengali).
+        return text
+
+    delta = dst_offset - src_offset
+    out: list[str] = []
+    upper = src_offset + _BLOCK_SIZE
+    for ch in text:
+        cp = ord(ch)
+        if src_offset <= cp < upper:
+            out.append(chr(cp + delta))
+        else:
+            out.append(ch)
+    return "".join(out)

--- a/tests/test_indic.py
+++ b/tests/test_indic.py
@@ -1,0 +1,125 @@
+import pytest
+
+from openodia import indic
+from openodia.indic import SCRIPTS
+
+
+class TestScriptsConstant:
+    def test_contains_all_supported(self) -> None:
+        for s in [
+            "devanagari",
+            "bengali",
+            "assamese",
+            "gurmukhi",
+            "gujarati",
+            "odia",
+            "tamil",
+            "telugu",
+            "kannada",
+            "malayalam",
+        ]:
+            assert s in SCRIPTS
+
+
+class TestOdiaToDevanagari:
+    def test_basic_consonant(self) -> None:
+        # Odia କ (U+0B15) → Devanagari क (U+0915)
+        assert indic.transliterate("କ", "odia", "devanagari") == "क"
+
+    def test_basic_word(self) -> None:
+        # ଭାରତ → भारत
+        assert indic.transliterate("ଭାରତ", "odia", "devanagari") == "भारत"
+
+    def test_digits(self) -> None:
+        # ୦ (U+0B66) → ० (U+0966)
+        assert indic.transliterate("୦୧୨", "odia", "devanagari") == "०१२"
+
+
+class TestDevanagariToOdia:
+    def test_basic_word(self) -> None:
+        assert indic.transliterate("भारत", "devanagari", "odia") == "ଭାରତ"
+
+    def test_namaste(self) -> None:
+        assert indic.transliterate("नमस्ते", "devanagari", "odia") == "ନମସ୍ତେ"
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize(
+        "scripts",
+        [
+            ("odia", "devanagari"),
+            ("odia", "bengali"),
+            ("odia", "telugu"),
+            ("odia", "kannada"),
+            ("odia", "malayalam"),
+            ("odia", "gujarati"),
+            ("odia", "gurmukhi"),
+            ("devanagari", "bengali"),
+        ],
+    )
+    def test_round_trip(self, scripts: tuple[str, str]) -> None:
+        a, b = scripts
+        word = "ଭାରତ" if a == "odia" else "भारत"
+        once = indic.transliterate(word, a, b)
+        twice = indic.transliterate(once, b, a)
+        assert twice == word
+
+
+class TestIdempotenceWhenSameScript:
+    def test_same_script_returns_input(self) -> None:
+        assert indic.transliterate("କ", "odia", "odia") == "କ"
+
+    def test_assamese_is_bengali_block(self) -> None:
+        # They alias — transliterating from one to the other should be a no-op.
+        assert indic.transliterate("কখগ", "bengali", "assamese") == indic.transliterate("কখগ", "assamese", "bengali") == "কখগ"
+
+
+class TestNonIndicPassThrough:
+    def test_latin_unchanged(self) -> None:
+        assert indic.transliterate("hello", "odia", "devanagari") == "hello"
+
+    def test_mixed_input(self) -> None:
+        out = indic.transliterate("hello କ world", "odia", "devanagari")
+        assert "hello" in out
+        assert "world" in out
+        assert "क" in out  # Devanagari ka
+
+    def test_whitespace_preserved(self) -> None:
+        assert indic.transliterate("କ ଖ", "odia", "devanagari") == "क ख"
+
+
+class TestUnknownScripts:
+    def test_unknown_from_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown from_script"):
+            indic.transliterate("क", "sanskrit", "odia")  # type: ignore[arg-type]
+
+    def test_unknown_to_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown to_script"):
+            indic.transliterate("କ", "odia", "sanskrit")  # type: ignore[arg-type]
+
+
+class TestEmpty:
+    def test_empty_input(self) -> None:
+        assert indic.transliterate("", "odia", "devanagari") == ""
+
+
+class TestLength:
+    """Codepoint count must be preserved."""
+
+    @pytest.mark.parametrize(
+        "text, from_, to_",
+        [
+            ("କଖଗ", "odia", "devanagari"),
+            ("ନମସ୍କାର ଓଡ଼ିଆ", "odia", "telugu"),
+        ],
+    )
+    def test_length_unchanged(self, text: str, from_: str, to_: str) -> None:
+        assert len(indic.transliterate(text, from_, to_)) == len(text)
+
+
+class TestPublicAPI:
+    def test_submodule_accessible(self) -> None:
+        import openodia
+
+        assert openodia.indic is indic
+        assert callable(openodia.indic.transliterate)


### PR DESCRIPTION
Closes #196.

## What

New `openodia.indic` submodule:

- **`transliterate(text, from_script, to_script)`** — script-only transliteration via Unicode block-offset addition.
- **`SCRIPTS`** — tuple of supported script names.

```python
indic.transliterate(\"ଓଡ଼ିଆ\", \"odia\", \"devanagari\")     # 'ओड़िआ'
indic.transliterate(\"नमस्ते\", \"devanagari\", \"odia\")    # 'ନମସ୍ତେ'
```

## Supported scripts

Devanagari, Bengali, Assamese (shares Bengali block), Gurmukhi, Gujarati, Odia, Tamil, Telugu, Kannada, Malayalam.

## How it works

Indic Unicode blocks are laid out in parallel — characters at the same offset within their block represent the same phonetic value. Transliteration is therefore a per-codepoint offset addition. Non-Indic input (Latin, digits, whitespace, punctuation, other Indic blocks) passes through unchanged.

The function is **length-preserving** by construction.

## Tests & coverage

```
tests/test_indic.py ......................... [100%]
25 passed in 0.10s

Name                         Stmts   Miss  Cover
-------------------------------------------------
openodia/indic/__init__.py       2      0   100%
openodia/indic/_indic.py        24      0   100%
-------------------------------------------------
TOTAL                           26      0   100%
```

Full suite: **318 passed**. No regressions.

## Edge cases covered

- Odia → Devanagari single consonant, full word (`ଭାରତ` → `भारत`), digits (`୦୧୨` → `०१२`).
- Devanagari → Odia word, `नमस्ते` → `ନମସ୍ତେ`.
- Round-trip property across 8 script pairs (returns to the original input).
- Same-script no-op.
- Bengali ↔ Assamese aliasing (same Unicode block → no-op).
- Non-Indic input passthrough (Latin, mixed content, whitespace).
- Unknown source/destination script raises `ValueError`.
- Empty input.
- Length is preserved across mixed Odia / whitespace input.

## Backward compatibility

Pure addition. Accessed as `openodia.indic.X`.

## Docs

`docs/index.md` \"Indic transliteration\" section with the Tamil caveat note (Tamil has only one consonant per articulation group → aspirated/voiced consonants land on unassigned codepoints, surfaced rather than silently collapsed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)