### PR TITLE
Drop the FOSSA licence badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
   <a href="https://github.com/soumendrak/openodia/actions/workflows/codecov.yml"><img alt="Code coverage" src="https://github.com/soumendrak/openodia/actions/workflows/codecov.yml/badge.svg"></a>
   <a href="https://github.com/soumendrak/openodia/blob/main/LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="https://codecov.io/gh/soumendrak/openodia"><img alt="code coverage" src="https://codecov.io/gh/soumendrak/openodia/branch/main/graph/badge.svg?token=1TOQIKGDQ2"/></a>
-  <a href="https://app.fossa.com/projects/git%2Bgithub.com%2Fsoumendrak%2Fopenodia?ref=badge_shield" alt="FOSSA Status"><img src="https://app.fossa.com/api/projects/git%2Bgithub.com%2Fsoumendrak%2Fopenodia.svg?type=shield" alt="license"/></a>
   <a href="https://pepy.tech/project/openodia" alt="downloads"><img src="https://static.pepy.tech/personalized-badge/openodia?period=total&units=none&left_color=black&right_color=orange&left_text=Downloads"/></a>
 </h4>
 
@@ -53,6 +52,4 @@ For usage and further documentation please visit the [Documentation](https://ope
 
 ## License
 
-<a align="center">
-<a href="https://app.fossa.com/projects/git%2Bgithub.com%2Fsoumendrak%2Fopenodia?ref=badge_large" alt="FOSSA Status"><img src="https://app.fossa.com/api/projects/git%2Bgithub.com%2Fsoumendrak%2Fopenodia.svg?type=large"/></a>
-</a>
+Released under the [MIT License](LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,6 @@
   <a href="https://github.com/soumendrak/openodia/actions/workflows/codecov.yml"><img alt="Code coverage" src="https://github.com/soumendrak/openodia/actions/workflows/codecov.yml/badge.svg"></a>
   <a href="https://github.com/soumendrak/openodia/blob/main/LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="https://codecov.io/gh/soumendrak/openodia"><img alt="code coverage" src="https://codecov.io/gh/soumendrak/openodia/branch/main/graph/badge.svg?token=1TOQIKGDQ2"/></a>
-  <a href="https://app.fossa.com/projects/git%2Bgithub.com%2Fsoumendrak%2Fopenodia?ref=badge_shield" alt="FOSSA Status"><img src="https://app.fossa.com/api/projects/git%2Bgithub.com%2Fsoumendrak%2Fopenodia.svg?type=shield" alt="license"/></a>
   <a href="https://pepy.tech/project/openodia" alt="downloads"><img src="https://static.pepy.tech/personalized-badge/openodia?period=total&units=none&left_color=black&right_color=orange&left_text=Downloads"/></a>
 </h4>
 


### PR DESCRIPTION
## What this does

Removes FOSSA's footprint in the repository — the shield badge in `README.md` and `docs/index.md`, and the large badge in the README licence section, replaced with a plain pointer to the LICENSE file. The MIT badge already in the header keeps the licence visible, so nothing is lost.

## ⚠️ This does NOT remove the check

`License Compliance` is a status posted by the **FOSSA GitHub App**, not by any workflow in this repo — there is no `.fossa.yml` and no workflow file to delete. Removing it requires uninstalling the app under **Settings → GitHub Apps → FOSSA**, which cannot be done from a pull request. This PR only cleans up the badges.

It is also **not a required status check** (`main` has no required contexts configured), so it has never blocked a merge.

## On the "it never runs" premise

Worth correcting before this is merged on that basis — the check has not always been stuck. On PR head commits it resolved **successfully** as recently as 2026-05-27:

| Commit | PR | `License Compliance` |
|---|---|---|
| `2c3f29b` | #224 | success |
| `e3452b9` | #222 | success |
| `9204620` | #219 | success |
| `0d5a556` | #244 | **pending** |
| `e489202` | #245 | **pending** |
| `af038ec` | main | **no status reported** |

So this is a recent breakage of the FOSSA integration — expired token, lapsed subscription, or revoked app permissions are the usual causes — rather than a check that never worked. If licence scanning is still wanted, fixing the integration is the alternative to removing it. If it isn't wanted, uninstalling the app is the step that actually stops the pending status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)