### PR TITLE
Make the release job safe when merges land back to back

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,13 +68,29 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
       - name: Build package
         run: uv build
-      # --check-url skips files already on PyPI, so a merge that does not bump the
-      # version is a no-op instead of a "File already exists" failure.
+      # --check-url skips files already on PyPI, but the simple index is CDN-cached
+      # and can still be stale seconds after an upload, so a concurrent run racing
+      # this one would try to re-upload and fail. Re-publishing a version that is
+      # already there is a no-op, not an error; anything else still fails the job.
       - name: Publish to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish --check-url https://pypi.org/simple/
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if output=$(uv publish --check-url https://pypi.org/simple/ 2>&1); then
+            echo "$output"
+            exit 0
+          fi
+          echo "$output"
+          if grep -q 'File already exists' <<<"$output"; then
+            echo "::notice::${VERSION} is already on PyPI; nothing to upload."
+            exit 0
+          fi
+          exit 1
       # Tags are unprefixed here to match the existing ones (0.1.11, 0.1.12).
+      # --target pins the tag to the commit that was actually built; without it
+      # `gh release create` tags whatever the default branch points at when the
+      # call lands, which is a different commit if another merge slipped in.
       - name: Tag the release and publish notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,4 +102,5 @@ jobs:
           fi
           gh release create "${VERSION}" dist/* \
             --title "${VERSION}" \
+            --target "${GITHUB_SHA}" \
             --generate-notes


### PR DESCRIPTION
Follow-up to the 0.1.13 release, which surfaced two flaws in the release job. Both were caused by #244 and #246 merging 37 seconds apart, so two release runs raced.

## 1. The second run went red on a duplicate upload

`--check-url` was supposed to prevent this, but PyPI's simple index is CDN-cached and still didn't list the file the first run had uploaded a minute earlier, so uv concluded it had work to do and got `400 File already exists`.

Checking the *failure* is reliable where checking the index isn't. A duplicate upload is now a no-op; everything else still fails.

Verified against a stubbed `uv` covering all four outcomes:

| Scenario | Exit |
|---|---|
| Successful upload | 0 |
| File already exists | 0 (no-op) |
| Invalid API token | **1** |
| Connection failure | **1** |

The last two matter most — the point is to swallow the duplicate, not to make the step unable to fail.

## 2. The tag landed on the wrong commit

`gh release create` without `--target` tags whatever the default branch points at when the call lands, not the commit that was checked out and built.

The `0.1.13` release was created at 02:40:44 and #246 merged at 02:40:45, so the tag points at `fd3a104` while the published artifacts were built from its parent `3f32be2`. The visible symptom: the PyPI description for 0.1.13 still carries the FOSSA badge that the tagged tree no longer has.

`--target "${GITHUB_SHA}"` pins the tag to the built commit.

## Not fixed here

`0.1.13`'s existing tag is left pointing where it is — moving a published tag is worse than the inconsistency. The next release will be correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)