### PR TITLE
Release only when the version is not already on PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,21 +61,44 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install uv
-      - name: Read the version being released
-        id: version
+      # A release is warranted only when pyproject declares a version PyPI does not
+      # have yet. Every other push to main rebuilds an already-published version,
+      # and since README.md is embedded in the wheel metadata that rebuild is a
+      # different artifact, which the publish step is right to reject.
+      - name: Decide whether this push releases
+        id: gate
         run: |
           version=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+          status=$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/openodia/${version}/json")
+          case "$status" in
+            200)
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::openodia ${version} is already on PyPI. Bump the version in pyproject.toml to release."
+              ;;
+            404)
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::openodia ${version} is not on PyPI yet; releasing it."
+              ;;
+            *)
+              # Anything else means we could not tell. Fail rather than guess, so a
+              # PyPI outage never silently skips or duplicates a release.
+              echo "::error::Unexpected HTTP ${status} from PyPI while checking ${version}."
+              exit 1
+              ;;
+          esac
       - name: Build package
+        if: steps.gate.outputs.publish == 'true'
         run: uv build
       # --check-url skips files already on PyPI, but the simple index is CDN-cached
       # and can still be stale seconds after an upload, so a concurrent run racing
       # this one would try to re-upload and fail. Re-publishing a version that is
       # already there is a no-op, not an error; anything else still fails the job.
       - name: Publish to PyPI
+        if: steps.gate.outputs.publish == 'true'
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.gate.outputs.version }}
         run: |
           if output=$(uv publish --check-url https://pypi.org/simple/ 2>&1); then
             echo "$output"
@@ -92,9 +115,10 @@ jobs:
       # `gh release create` tags whatever the default branch points at when the
       # call lands, which is a different commit if another merge slipped in.
       - name: Tag the release and publish notes
+        if: steps.gate.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.gate.outputs.version }}
         run: |
           if gh release view "${VERSION}" >/dev/null 2>&1; then
             echo "Release ${VERSION} already exists, nothing to do."


### PR DESCRIPTION
`main` is red again. Three release runs failed after 0.1.13 shipped — the #247 merge and both dependabot merges (#241, #242).

## What's actually wrong

The `Release` job builds and publishes on **every** push to main, regardless of what the version says. So any merge that doesn't bump the version rebuilds an already-published version and tries to upload it.

My previous fix tolerated `File already exists`, which turned out to be the wrong target. The error this time was different:

```
error: Local file and index file do not match for openodia-0.1.13-py3-none-any.whl.
Local:  sha256=f644a4cc...
Remote: sha256=7f5cf15a...
```

`README.md` is embedded in the wheel as `long_description`, so once #246 edited it, the rebuild of 0.1.13 became a genuinely different artifact. I confirmed builds are reproducible — rebuilding main locally produced `f644a4cc`, byte-identical to the hash CI computed. **The mismatch is real, and `--check-url` refusing it is correct behaviour, not a bug to swallow.**

Chasing individual error strings was the wrong approach. The job shouldn't be attempting the upload at all.

## The fix

Decide up front whether a release is warranted, and skip `Build`, `Publish`, and `Tag` when it isn't. An ordinary merge becomes a clean no-op.

The check reads the HTTP status explicitly rather than relying on curl's exit code:

| PyPI response | Action |
|---|---|
| `200` — version exists | Skip; log a notice to bump the version |
| `404` — version is new | Release it |
| anything else | **Fail** |

That last row matters: a PyPI outage must never silently skip a real release or make the job guess. A false "not published" is safe because the publish step would then fail loudly; a false "already published" would silently swallow a release, and only a definite `200` produces it.

## Verification

Against live PyPI: `0.1.12` and `0.1.13` return 200 and skip, `0.1.14` returns 404 and would release.

## After this merges

Merging this triggers a run that should go **green while publishing nothing** — main is at 0.1.13, which is already out. That is the fix demonstrating itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)